### PR TITLE
Use gunicorn at Dockerfile to spin up the django application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN pip install -r requirements.txt
 
 EXPOSE 8000
 
-CMD ["sh", "-c", "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"]
+CMD ["sh", "-c", "python manage.py migrate && gunicorn -b 0.0.0.0:8000 tola.wsgi"]

--- a/tola/urls.py
+++ b/tola/urls.py
@@ -7,6 +7,7 @@ from django.views.generic import TemplateView
 from rest_framework import routers
 from django.conf import settings
 from django.conf.urls.static import static
+from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from rest_framework.authtoken import views as auth_views
 from django.contrib.auth import views as authviews
 from django.contrib.auth import forms as authforms
@@ -143,3 +144,4 @@ urlpatterns = [ # rest framework
 
     ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
+urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
Extended the Dockerfile and added gunicorn as a real wsgi server infront of the django application. Needed to extend the `tola.urls` module's `urlpatterns` variable otherwise static resources hadn't been able to be served by gunicorn - don't know why this works with `manage.py runserver`