### PR TITLE
Add new fields in the feed endpoint of workflowlevel1

### DIFF
--- a/feed/serializers.py
+++ b/feed/serializers.py
@@ -27,6 +27,9 @@ class WorkflowLevel1Serializer(serializers.HyperlinkedModelSerializer):
     workflow_key = serializers.UUIDField(read_only=True)
     id = serializers.ReadOnlyField()
     status = serializers.SerializerMethodField()
+    budget = serializers.ReadOnlyField()
+    actuals = serializers.ReadOnlyField()
+    difference = serializers.SerializerMethodField()
 
     def get_status(self, obj):
         get_projects = WorkflowLevel2.objects.all().filter(workflowlevel1=obj)
@@ -48,6 +51,9 @@ class WorkflowLevel1Serializer(serializers.HyperlinkedModelSerializer):
             calculated_status = "green"
 
         return calculated_status
+
+    def get_difference(self, obj):
+        return obj.budget - obj.actuals
 
     class Meta:
         model = WorkflowLevel1

--- a/feed/views.py
+++ b/feed/views.py
@@ -83,7 +83,7 @@ class WorkflowLevel1ViewSet(viewsets.ModelViewSet):
 
     def list(self, request):
         if request.user.is_superuser:
-            queryset = WorkflowLevel1.objects.all()
+            queryset = WorkflowLevel1.objects.all().annotate(budget=Sum('workflowlevel2__total_estimated_budget'), actuals=Sum('workflowlevel2__actual_cost'))
         elif 'OrgAdmin' in request.user.groups.values_list('name', flat=True):
             user_org = TolaUser.objects.get(user=request.user).organization
             queryset = WorkflowLevel1.objects.all().filter(organization=user_org)


### PR DESCRIPTION
Added three new fields in the feed endpoint of workflowlevel1 to calculate for each workflowlevel1 the sums of the related workflowlevel 2 budget and actual expenses.
Implementation of the issue [#297](https://github.com/toladata/TolaDataV2/issues/297) 