### PR TITLE
When creating a new level, it should inherit the organization from WorkflowLevel1

### DIFF
--- a/indicators/models.py
+++ b/indicators/models.py
@@ -147,6 +147,8 @@ class Level(models.Model):
         if self.create_date == None:
             self.create_date = datetime.now()
         self.edit_date = datetime.now()
+        if not self.organization:
+            self.organization = self.workflowlevel1.organization
         super(Level, self).save(*args, **kwargs)
 
 

--- a/indicators/test.py
+++ b/indicators/test.py
@@ -1,14 +1,14 @@
+from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test import RequestFactory
 from django.test import Client
-from indicators.models import Indicator, IndicatorType, DisaggregationType, Frequency, CollectedData
+
+from indicators.models import Indicator, IndicatorType, DisaggregationType, Frequency, CollectedData, Level
 from workflow.models import WorkflowLevel1, Country, Organization
-from django.contrib.auth.models import User
 
 
 class IndicatorTestCase(TestCase):
-
-    fixtures = ['fixtures/001_organization.json','fixtures/config/sites.json']
+    fixtures = ['fixtures/001_organization.json', 'fixtures/config/sites.json']
 
     def setUp(self):
         new_organization = Organization.objects.create(name="tola")
@@ -24,7 +24,8 @@ class IndicatorTestCase(TestCase):
         new_indicator_type = IndicatorType.objects.create(indicator_type="testtype")
         new_indicator_type.save()
         get_indicator_type = IndicatorType.objects.get(indicator_type="testtype")
-        new_disaggregation = DisaggregationType.objects.create(organization=get_organization,disaggregation_type="disagg")
+        new_disaggregation = DisaggregationType.objects.create(organization=get_organization,
+                                                               disaggregation_type="disagg")
         new_disaggregation.save()
         get_disaggregation = DisaggregationType.objects.get(disaggregation_type="disagg")
         new_frequency = Frequency.objects.create(frequency="newfreq")
@@ -32,24 +33,23 @@ class IndicatorTestCase(TestCase):
         get_frequency = Frequency.objects.get(frequency="newfreq")
         user = User.objects.create_user('john', 'lennon@thebeatles.com', 'johnpassword')
         user.save()
-        get_user = User.objects.get(username='john')
-        new_indicator = Indicator.objects.create(name="testindicator",number="1.2.3",source="testing",
-                                                 baseline="10",lop_target="10", reporting_frequency=get_frequency)
+        User.objects.get(username='john')
+        new_indicator = Indicator.objects.create(name="testindicator", number="1.2.3", source="testing",
+                                                 baseline="10", lop_target="10", reporting_frequency=get_frequency)
         new_indicator.save()
         new_indicator.disaggregation.add(get_disaggregation)
         new_indicator.indicator_type.add(get_indicator_type)
         new_indicator.workflowlevel1.add(get_program)
 
         get_indicator = Indicator.objects.get(name="testindicator")
-        new_collected = CollectedData.objects.create(achieved="20", description="somevaluecollected", indicator=get_indicator)
+        new_collected = CollectedData.objects.create(achieved="20", description="somevaluecollected",
+                                                     indicator=get_indicator)
         new_collected.save()
 
     def test_indicator_exists(self):
-        #Check for Indicator object
         get_indicator = Indicator.objects.get(name="testindicator")
         self.assertEqual(Indicator.objects.filter(id=get_indicator.id).count(), 1)
 
     def test_collected_exists(self):
-        #Check for CollectedData object
         get_collected = CollectedData.objects.get(description="somevaluecollected")
         self.assertEqual(CollectedData.objects.filter(id=get_collected.id).count(), 1)

--- a/indicators/test_models.py
+++ b/indicators/test_models.py
@@ -1,0 +1,16 @@
+from django.test import TestCase
+
+from indicators.models import Level
+from workflow.models import WorkflowLevel1, Organization
+
+
+class LevelModelTest(TestCase):
+    def test_save_level_org_same_as_wflvl1(self):
+        self.wflvl1 = WorkflowLevel1.objects.create(name='WorkflowLevel1')
+        self.organization = Organization.objects.create(name='Org')
+        org = Organization.objects.first()
+        self.wflvl1.organization = self.organization
+        self.wflvl1.save()
+        level = Level.objects.create(name='TestIndicator', workflowlevel1=self.wflvl1)
+        level.save()
+        self.assertEqual(level.organization, self.organization)


### PR DESCRIPTION
## Ticket

https://github.com/toladata/TolaDataV2/issues/366