### PR TITLE
Ignore if Indicator to delete is not in Elasticsearch #360

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,6 +2,8 @@
 pipeline:
   build:
     image: python:${PYTHON_VERSION}
+    environment:
+      - ELASTICSEARCH_URL=http://elasticsearch:9200/
     commands:
       - pip install -r requirements-ci.txt
       - python manage.py test
@@ -45,6 +47,11 @@ pipeline:
       status: [failure]
       event: [push, tag]
       branches: [master, dev-v2]
+
+services:
+  elasticsearch:
+    container_name: elasticsearch
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.0.0-alpha2
 
 matrix:
   PYTHON_VERSION:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: python
 python:
   - "2.7"
+services:
+  - elasticsearch
+before_script:
+  - sleep 10
 install:
   - pip install -r requirements-ci.txt
-script: python manage.py test 
+script: python manage.py test -v 2
+env:
+  - ELASTICSEARCH_URL=http://127.0.0.1:9200/
+

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,8 +1,13 @@
-version: "2"
+version: "2.1"
 
 services:
   postgres:
     container_name: postgres
+    healthcheck:
+      test: "pg_isready -h localhost -p 5432 -q -U postgres"
+      interval: 3s
+      timeout: 5s
+      retries: 5
     image: postgres:9.6
     environment:
       POSTGRES_DB: tola_activity
@@ -15,6 +20,11 @@ services:
     restart: always
   elasticsearch:
     container_name: elasticsearch
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:9200"]
+      interval: 3s
+      timeout: 5s
+      retries: 5
     image: docker.elastic.co/elasticsearch/elasticsearch:6.0.0-alpha2
     ports:
       - "9200:9200"

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -13,7 +13,13 @@ services:
     ports:
       - "5432:5432"
     restart: always
-
+  elasticsearch:
+    container_name: elasticsearch
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.0.0-alpha2
+    ports:
+      - "9200:9200"
+    environment:
+      - xpack.security.enabled=false
   web:
     build:
       context: .
@@ -26,6 +32,7 @@ services:
       - "8000:8000"
     depends_on:
       - postgres
+      - elasticsearch
     environment:
       - DJANGO_SETTINGS_MODULE=tola.settings.dev
       - TOLA_DEBUG=True
@@ -37,6 +44,7 @@ services:
       - TOLA_DB_PASS=root
       - TOLA_DB_HOST=postgres
       - TOLA_DB_PORT=5432
+      - ELASTICSEARCH_URL=http://elasticsearch:9200/
       - SOCIAL_AUTH_GOOGLE_OAUTH2_KEY=445847194486-gl2v6ud6ll65vf06vbjaslqqgejad61k.apps.googleusercontent.com
       - SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET=qAAdNMQy77Vwqgj4YgOu20f7
       - SOCIAL_AUTH_LOGIN_REDIRECT_URL=http://dev-v2.tolaactivity.app.tola.io/

--- a/indicators/models.py
+++ b/indicators/models.py
@@ -1,12 +1,13 @@
+from datetime import datetime, timedelta
 from decimal import Decimal
 import uuid
 
 from django.db import models
 from django.contrib import admin
-from datetime import datetime, timedelta
 from django.utils import timezone
 from simple_history.models import HistoricalRecords
 
+from search.exceptions import ValueNotFoundError
 from workflow.models import WorkflowLevel1, Sector, SiteProfile, WorkflowLevel2, Country, Office, Documentation, TolaUser,\
     Organization
 
@@ -380,7 +381,10 @@ class Indicator(models.Model): # TODO change back to SecurityModel
         super(Indicator, self).delete(*args, **kwargs)
 
         ei = ElasticsearchIndexer()
-        ei.delete_indicator(self.id)
+        try:
+            ei.delete_indicator(self.id)
+        except ValueNotFoundError:
+            pass
 
     @property
     def just_created(self):

--- a/search/exceptions.py
+++ b/search/exceptions.py
@@ -1,0 +1,2 @@
+class ValueNotFoundError(Exception):
+    pass

--- a/search/models.py
+++ b/search/models.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from datetime import datetime
-import uuid
 
 from django.contrib import admin
 from django.db import models

--- a/search/test_utils.py
+++ b/search/test_utils.py
@@ -1,0 +1,10 @@
+from django.test import TestCase
+
+from indicators.models import Indicator
+from search.utils import ElasticsearchIndexer
+
+
+class ElasticsearchIndexerTest(TestCase):
+    def test_es_connection(self):
+        indexer = ElasticsearchIndexer()
+        self.assertTrue(indexer.es.ping(), "Cannot connect to Elasticsearch")

--- a/search/test_utils.py
+++ b/search/test_utils.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 
 from indicators.models import Indicator
+from search.exceptions import ValueNotFoundError
 from search.utils import ElasticsearchIndexer
 
 
@@ -8,3 +9,12 @@ class ElasticsearchIndexerTest(TestCase):
     def test_es_connection(self):
         indexer = ElasticsearchIndexer()
         self.assertTrue(indexer.es.ping(), "Cannot connect to Elasticsearch")
+
+    def test_create_and_delete_indicator(self):
+        indexer = ElasticsearchIndexer()
+        indicator = Indicator.objects.create(name="TestIndicator")
+        indexer.delete_indicator(indicator.pk)
+
+    def test_delete_unexisting_indicator_raises_exception(self):
+        indexer = ElasticsearchIndexer()
+        self.assertRaises(ValueNotFoundError, indexer.delete_indicator, 288)

--- a/search/tests.py
+++ b/search/tests.py
@@ -1,6 +1,0 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
-from django.test import TestCase
-
-# Create your tests here.

--- a/search/utils.py
+++ b/search/utils.py
@@ -16,7 +16,7 @@ class ElasticsearchIndexer:
     To seperate indices of different servers a prefix can be defined in settings
     """
     if settings.ELASTICSEARCH_URL is not None:
-        es = Elasticsearch([settings.ELASTICSEARCH_URL])
+        es = Elasticsearch([settings.ELASTICSEARCH_URL], timeout=30, max_retries=10, retry_on_timeout=True)
     else:
         es = None
 


### PR DESCRIPTION
## Purpose

The API is responding with 500 error if an indicator is not found in Elasticsearch. The best way to solve this situation is to log a warning and continue without breaking the API.

The indicator may not be in Elasticsearch because this value can be coming from fixtures or because Elasticsearch was temporarily deactivated.