### PR TITLE
Add current Org to new Stakeholder 

### DIFF
--- a/feed/serializers.py
+++ b/feed/serializers.py
@@ -281,6 +281,13 @@ class LevelSerializer(serializers.HyperlinkedModelSerializer):
 class StakeholderSerializer(serializers.HyperlinkedModelSerializer):
     id = serializers.ReadOnlyField()
 
+    def create(self, validated_data, **kwargs):
+        user = self.context['request'].user
+        user_org = TolaUser.objects.get(user=user).organization
+        validated_data['organization'] = user_org
+
+        return super(StakeholderSerializer, self).create(validated_data)
+
     class Meta:
         model = Stakeholder
         fields = '__all__'

--- a/feed/serializers.py
+++ b/feed/serializers.py
@@ -177,50 +177,6 @@ class ProgramIndicatorSerializer(serializers.ModelSerializer):
         fields = ('id', 'name', 'indicators_count', 'indicator_set')
 
 
-class IndicatorTypeLightSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = IndicatorType
-        fields = ('id', 'indicator_type')
-
-
-class IndicatorLevelLightSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Level
-        fields = ('id', 'name')
-
-
-class IndicatorLightSerializer(serializers.ModelSerializer):
-    sector = serializers.SerializerMethodField()
-    indicator_type = IndicatorTypeLightSerializer(many=True, read_only=True)
-    level = IndicatorLevelLightSerializer(many=True, read_only=True)
-    datacount = serializers.SerializerMethodField()
-
-    def get_datacount(self, obj):
-        # Returns the number of collecteddata points by an indicator
-        return obj.collecteddata_set.count()
-
-    def get_sector(self, obj):
-        if obj.sector is None:
-            return ''
-        return {"id": obj.sector.id, "name": obj.sector.sector}
-
-    class Meta:
-        model = Indicator
-        fields = ('name', 'number', 'lop_target', 'indicator_type', 'level', 'sector', 'datacount')
-
-
-class ProgramIndicatorSerializer(serializers.ModelSerializer):
-    indicator_set = IndicatorLightSerializer(many=True, read_only=True)
-    indicators_count = serializers.SerializerMethodField()
-
-    def get_indicators_count(self, obj):
-        return obj.indicator_set.count()
-
-    class Meta:
-        model = WorkflowLevel1
-        fields = ('id', 'name', 'indicators_count', 'indicator_set')
-
-
 class FrequencySerializer(serializers.HyperlinkedModelSerializer):
     id = serializers.ReadOnlyField()
 

--- a/feed/tests/test_stakeholderview.py
+++ b/feed/tests/test_stakeholderview.py
@@ -1,0 +1,91 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
+
+from feed.views import StakeholderViewSet
+from workflow.models import Stakeholder, Organization, TolaUser, \
+    WorkflowLevel1, WorkflowTeam
+
+
+class StakeholderViewsTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user('john', 'lennon@thebeatles.com',
+                                             'johnpassword')
+        self.user.is_superuser = True
+        self.user.is_staff = True
+        self.user.save()
+
+        organization = Organization.objects.create(name="TestOrg_0")
+        Stakeholder.objects.create(name='Stakeholder_0',
+                                   organization=organization)
+
+        factory = APIRequestFactory()
+        self.request_get = factory.get('/api/stakeholder/')
+        self.request_post = factory.post('/api/stakeholder/')
+
+    def test_list_stakeholder_superuser(self):
+        self.request_get.user = self.user
+        view = StakeholderViewSet.as_view({'get': 'list'})
+        response = view(self.request_get)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 0)
+
+    def test_list_stakeholder_normaluser(self):
+        self.user.is_superuser = False
+        self.user.is_staff = False
+        self.user.save()
+        organization = Organization.objects.create(name="TestOrg")
+        TolaUser.objects.create(user=self.user, organization=organization)
+
+        self.request_get.user = self.user
+        view = StakeholderViewSet.as_view({'get': 'list'})
+        response = view(self.request_get)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 0)
+
+    def test_list_stakeholder_normaluser_one_result(self):
+        self.user.is_superuser = False
+        self.user.is_staff = False
+        self.user.save()
+        organization = Organization.objects.create(name="TestOrg_1")
+        tola_user = TolaUser.objects.create(user=self.user,
+                                            organization=organization)
+        wflvl1 = WorkflowLevel1.objects.create(name='WorkflowLevel1')
+        WorkflowTeam.objects.create(workflow_user=tola_user,
+                                    workflowlevel1=wflvl1)
+        stk = Stakeholder.objects.create(name='Stakeholder_0',
+                                         organization=organization)
+        stk.workflowlevel1.add(wflvl1)
+
+        self.request_get.user = self.user
+        view = StakeholderViewSet.as_view({'get': 'list'})
+        response = view(self.request_get)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+
+    def test_create_stakeholder_normaluser_one_result(self):
+        self.user.is_superuser = False
+        self.user.is_staff = False
+        self.user.save()
+        organization = Organization.objects.create(name="TestOrg_1")
+        tola_user = TolaUser.objects.create(user=self.user,
+                                            organization=organization)
+        wflvl1 = WorkflowLevel1.objects.create(name='WorkflowLevel1')
+        WorkflowTeam.objects.create(workflow_user=tola_user,
+                                    workflowlevel1=wflvl1)
+
+        # create stakeholder via POST request
+        data = {'workflowlevel1': [
+            'http://testserver/api/workflowlevel1/%s/' % wflvl1.id]}
+        self.request_post = APIRequestFactory().post('/api/stakeholder/', data)
+        self.request_post.user = self.user
+        view = StakeholderViewSet.as_view({'post': 'create'})
+        response = view(self.request_post)
+        self.assertEqual(response.status_code, 201)
+
+        # check if the obj created has the user organization
+        self.request_get.user = self.user
+        view = StakeholderViewSet.as_view({'get': 'list'})
+        response = view(self.request_get)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)


### PR DESCRIPTION
## Purpose
When a user was creating a new stakeholder, his/her organization wasn't being added to the stakeholder record. Now, this information is added when anybody creates a stakeholder.

#### Link
Issue TolaDataV2/[#349](https://github.com/toladata/TolaDataV2/issues/349)