### PR TITLE
Add URL in GroupSerializer and Change GroupViewSet

### DIFF
--- a/factories/user_models.py
+++ b/factories/user_models.py
@@ -11,3 +11,11 @@ class User(DjangoModelFactory):
     last_name = 'Yorke'
     username = lazy_attribute(lambda o: slugify(o.first_name + '.' + o.last_name))
     email = lazy_attribute(lambda o: o.username + "@testenv.com")
+
+
+class Group(DjangoModelFactory):
+    class Meta:
+        model = 'auth.Group'
+        django_get_or_create = ('name',)
+
+    name = 'ProgramAdmin'

--- a/feed/serializers.py
+++ b/feed/serializers.py
@@ -4,8 +4,7 @@ from workflow.models import *
 from indicators.models import *
 from formlibrary.models import *
 from django.contrib.auth.models import User, Group
-from rest_framework.serializers import ReadOnlyField
-from django.db.models import Count, Sum
+from rest_framework.reverse import reverse
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -16,6 +15,11 @@ class UserSerializer(serializers.ModelSerializer):
 
 
 class GroupSerializer(serializers.ModelSerializer):
+    url = serializers.SerializerMethodField('get_self')
+
+    def get_self(self, obj):
+        request = self.context['request']
+        return reverse('group-detail', kwargs={'pk': obj.id}, request=request)
 
     class Meta:
         model = Group

--- a/feed/tests/test_groupview.py
+++ b/feed/tests/test_groupview.py
@@ -1,0 +1,42 @@
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
+
+from feed.views import GroupViewSet
+import factories
+
+
+class GroupViewsTest(TestCase):
+    def setUp(self):
+        factories.Group()
+        factory = APIRequestFactory()
+        self.request_get = factory.get('/api/groups/')
+        self.request_post = factory.post('/api/groups/')
+
+    def test_list_groups_superuser(self):
+        self.request_get.user = factories.User.build(is_superuser=True,
+                                                     is_staff=True)
+        view = GroupViewSet.as_view({'get': 'list'})
+        response = view(self.request_get)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+
+    def test_list_groups_normaluser(self):
+        tola_user = factories.TolaUser()
+        self.request_get.user = tola_user.user
+        view = GroupViewSet.as_view({'get': 'list'})
+        response = view(self.request_get)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+
+    def test_create_group_error(self):
+        # create stakeholder via POST request
+        data = {'name': 'TestGroup'}
+        self.request_post = APIRequestFactory().post('/api/stakeholder/', data)
+        self.request_post.user = factories.User.build(is_superuser=False,
+                                                      is_staff=False)
+        view = GroupViewSet.as_view({'post': 'create'})
+
+        with self.assertRaises(AttributeError) as context:
+            view(self.request_post)
+            self.assertTrue('\'GroupViewSet\' object has no attribute '
+                            '\'create\'' in context.exception)

--- a/feed/views.py
+++ b/feed/views.py
@@ -61,7 +61,7 @@ class UserViewSet(viewsets.ModelViewSet):
     serializer_class = UserSerializer
 
 
-class GroupViewSet(viewsets.ModelViewSet):
+class GroupViewSet(viewsets.ReadOnlyModelViewSet):
     """
     A ViewSet for listing or retrieving users.
     """


### PR DESCRIPTION
## Purpose
Give the URL of the group in the API. Remove the possibility to create groups via API.

### Approach 
Added the URL field in the GroupSerializer and changed the viewset of GroupViewSet to `ReadOnlyModelViewSet`. 

Related issue: TolaDataV2/[#405](https://github.com/toladata/TolaDataV2/issues/405)