### PR TITLE
Remove the organization filter from workflowteam

### DIFF
--- a/factories/workflow_models.py
+++ b/factories/workflow_models.py
@@ -8,6 +8,7 @@ from workflow.models import (
     Organization as OrganizationM,
     SiteProfile as SiteProfileM,
     TolaUser as TolaUserM,
+    WorkflowTeam as WorkflowTeamM,
     WorkflowLevel1 as WorkflowLevel1M,
     WorkflowLevel2 as WorkflowLevel2M,
 )
@@ -56,6 +57,11 @@ class TolaUser(DjangoModelFactory):
     organization = SubFactory(Organization)
     position_description = 'Chief of Operations'
     country = SubFactory(Country, country='Germany', code='DE')
+
+
+class WorkflowTeam(DjangoModelFactory):
+    class Meta:
+        model = WorkflowTeamM
 
 
 class WorkflowLevel1(DjangoModelFactory):

--- a/feed/tests/test_disaggregationtypeview.py
+++ b/feed/tests/test_disaggregationtypeview.py
@@ -4,7 +4,6 @@ from rest_framework.test import APIRequestFactory
 import factories
 from feed.views import DisaggregationTypeViewSet
 from indicators.models import DisaggregationType
-from workflow.models import Organization
 
 
 class DisaggregationTypeViewsTest(TestCase):

--- a/feed/tests/test_groupview.py
+++ b/feed/tests/test_groupview.py
@@ -29,7 +29,7 @@ class GroupViewsTest(TestCase):
         self.assertEqual(len(response.data), 1)
 
     def test_create_group_error(self):
-        # create stakeholder via POST request
+        # create group via POST request
         data = {'name': 'TestGroup'}
         self.request_post = APIRequestFactory().post('/api/stakeholder/', data)
         self.request_post.user = factories.User.build(is_superuser=False,

--- a/feed/tests/test_workflowteamview.py
+++ b/feed/tests/test_workflowteamview.py
@@ -1,0 +1,41 @@
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
+
+import factories
+from feed.views import WorkflowTeamViewSet
+from workflow.models import WorkflowTeam
+
+
+class WorkflowTeamViewsTest(TestCase):
+    def setUp(self):
+        factories.WorkflowTeam()
+
+        factory = APIRequestFactory()
+        self.request_get = factory.get('/api/workflowteam/')
+
+    def test_list_workflowteam_superuser(self):
+        self.request_get.user = factories.User.build(is_superuser=True, is_staff=True)
+        view = WorkflowTeamViewSet.as_view({'get': 'list'})
+        response = view(self.request_get)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+
+    def test_list_workflowteam_normaluser(self):
+        tola_user = factories.TolaUser()
+        self.request_get.user = tola_user.user
+        view = WorkflowTeamViewSet.as_view({'get': 'list'})
+        response = view(self.request_get)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 0)
+
+    def test_list_workflowteam_normaluser_one_result(self):
+        tola_user = factories.TolaUser()
+        wflvl1 = factories.WorkflowLevel1()
+        WorkflowTeam.objects.create(workflowlevel1=wflvl1,
+                                    workflow_user=tola_user)
+
+        self.request_get.user = tola_user.user
+        view = WorkflowTeamViewSet.as_view({'get': 'list'})
+        response = view(self.request_get)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)

--- a/feed/views.py
+++ b/feed/views.py
@@ -1049,9 +1049,6 @@ class WorkflowTeamViewSet(viewsets.ModelViewSet):
     def list(self, request):
         if request.user.is_superuser:
             queryset = WorkflowTeam.objects.all()
-        elif 'OrgAdmin' in request.user.groups.values_list('name', flat=True):
-            user_org = TolaUser.objects.get(user=request.user).organization
-            queryset = WorkflowTeam.objects.all().filter(organization=user_org)
         else:
             user_level1 = getLevel1(request.user)
             queryset = WorkflowTeam.objects.all().filter(workflowlevel1__in=user_level1)


### PR DESCRIPTION
## Purpose
The WorkflowTeam shouldn't be filtered by an organization when a user is part of the _OrgAdmin_ group. We should remove this filter but keep the workflowlevel1filter.


Related issue: TolaDataV2/[#406](https://github.com/toladata/TolaDataV2/issues/406)