### PR TITLE
Fix filter Sites under the Program Tab

### DIFF
--- a/factories/workflow_models.py
+++ b/factories/workflow_models.py
@@ -1,6 +1,6 @@
 from django.template.defaultfilters import slugify
 from factory import DjangoModelFactory, lazy_attribute, LazyAttribute, \
-    SubFactory, post_generation
+    SubFactory
 
 from workflow.models import (
     Contact as ContactM,
@@ -76,14 +76,3 @@ class WorkflowLevel2(DjangoModelFactory):
         model = WorkflowLevel2M
 
     name = 'Help Syrians'
-
-    @post_generation
-    def site(self, create, extracted, **kwargs):
-        if not create:
-            # Simple build, do nothing.
-            return
-
-        if extracted:
-            # A list of site were passed in, use them
-            for site in extracted:
-                self.site.add(site)

--- a/feed/tests/test_siteprofileview.py
+++ b/feed/tests/test_siteprofileview.py
@@ -75,7 +75,8 @@ class SiteProfileViewsTest(TestCase):
                                           organization=tola_user.organization,
                                           country=self.country)
         wkf1 = factories.WorkflowLevel1()
-        factories.WorkflowLevel2.build(workflowlevel1=wkf1, site=site)
+        wkf2 = factories.WorkflowLevel2.create(workflowlevel1=wkf1)
+        wkf2.site.add(site)
 
         path = \
             '/api/siteprofile/?workflowlevel2__workflowlevel1=%s' % wkf1.id

--- a/feed/views.py
+++ b/feed/views.py
@@ -217,11 +217,10 @@ class SiteProfileViewSet(viewsets.ModelViewSet):
     limit to users logged in country permissions
     """
     def list(self, request):
-        if request.user.is_superuser:
-            queryset = SiteProfile.objects.all()
-        else:
+        queryset = self.filter_queryset(self.get_queryset())
+        if not request.user.is_superuser:
             tola_user = TolaUser.objects.get(user=request.user)
-            queryset = SiteProfile.objects.filter(organization=tola_user.organization)
+            queryset = queryset.filter(organization=tola_user.organization)
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
 


### PR DESCRIPTION
## Purpose
When using query parameters to fetch data from the API, it should return the info filtered based on the params.

#### Approach
- Changed the `list` method in the SiteProfileViewSet. Getting the `queryset` from the ViewSet and applying the filter before applying the other filters.

Related issue: TolaDataV2/[#379](https://github.com/toladata/TolaDataV2/issues/379)