### PR TITLE
Fix the permissions when handling raw data

### DIFF
--- a/feed/permissions.py
+++ b/feed/permissions.py
@@ -1,6 +1,8 @@
 from rest_framework import permissions
 from rest_framework.relations import ManyRelatedField
 
+from django.http import QueryDict
+
 from workflow.models import *
 from indicators.models import *
 from formlibrary.models import *
@@ -84,7 +86,8 @@ class AllowTolaRoles(permissions.BasePermission):
             wflvl1_serializer = view.serializer_class().get_fields()['workflowlevel1']
 
             # Check if the field is Many-To-Many or not
-            if wflvl1_serializer.__class__ == ManyRelatedField:
+            if wflvl1_serializer.__class__ == ManyRelatedField and \
+                    isinstance(request.data, QueryDict):
                 primitive_value = request.data.getlist('workflowlevel1')
             else:
                 primitive_value = request.data.get('workflowlevel1')

--- a/feed/tests/test_milestoneview.py
+++ b/feed/tests/test_milestoneview.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 from rest_framework.test import APIRequestFactory
 from rest_framework.reverse import reverse
 
+import json
 import factories
 from feed.views import MilestoneViewSet
 
@@ -18,6 +19,22 @@ class MilestoneViewTest(TestCase):
 
         data = {'name': 'Project Implementation'}
         self.request = APIRequestFactory().post('/api/milestone/', data)
+        self.request.user = self.user
+        view = MilestoneViewSet.as_view({'post': 'create'})
+        response = view(self.request)
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data['name'], u'Project Implementation')
+        self.assertEqual(response.data['created_by'], user_url)
+
+    def test_create_milestone_json(self):
+        user_url = reverse('user-detail', kwargs={'pk': self.user.id},
+                           request=self.request)
+
+        data = {'name': 'Project Implementation'}
+        self.request = APIRequestFactory().post(
+            '/api/milestone/', json.dumps(data),
+            content_type='application/json')
         self.request.user = self.user
         view = MilestoneViewSet.as_view({'post': 'create'})
         response = view(self.request)

--- a/feed/tests/test_sectorview.py
+++ b/feed/tests/test_sectorview.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 from rest_framework.test import APIRequestFactory
 from rest_framework.reverse import reverse
 
+import json
 import factories
 from feed.views import SectorViewSet
 
@@ -20,6 +21,21 @@ class SectorViewTest(TestCase):
 
         data = {'sector': 'Agriculture'}
         self.request = APIRequestFactory().post('/api/sector/', data)
+        self.request.user = self.user
+        view = SectorViewSet.as_view({'post': 'create'})
+        response = view(self.request)
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data['sector'], u'Agriculture')
+        self.assertEqual(response.data['created_by'], user_url)
+
+    def test_create_sector_json(self):
+        user_url = reverse('user-detail', kwargs={'pk': self.user.id},
+                           request=self.request)
+
+        data = {'sector': 'Agriculture'}
+        self.request = APIRequestFactory().post(
+            '/api/sector/', json.dumps(data), content_type='application/json')
         self.request.user = self.user
         view = SectorViewSet.as_view({'post': 'create'})
         response = view(self.request)

--- a/feed/tests/test_stakeholderview.py
+++ b/feed/tests/test_stakeholderview.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 from rest_framework.test import APIRequestFactory
 from rest_framework.reverse import reverse
 
+import json
 import factories
 from feed.views import StakeholderViewSet
 from workflow.models import Stakeholder, Organization, WorkflowLevel1, \
@@ -62,6 +63,32 @@ class StakeholderViewsTest(TestCase):
         data = {'workflowlevel1': [
             'http://testserver/api/workflowlevel1/%s/' % wflvl1.id]}
         self.request_post = APIRequestFactory().post('/api/stakeholder/', data)
+        self.request_post.user = self.tola_user.user
+        view = StakeholderViewSet.as_view({'post': 'create'})
+        response = view(self.request_post)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.data['created_by'], user_url)
+
+        # check if the obj created has the user organization
+        self.request_get.user = self.tola_user.user
+        view = StakeholderViewSet.as_view({'get': 'list'})
+        response = view(self.request_get)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+
+    def test_create_stakeholder_normaluser_one_result_json(self):
+        wflvl1 = WorkflowLevel1.objects.create(name='WorkflowLevel1')
+        WorkflowTeam.objects.create(workflow_user=self.tola_user,
+                                    workflowlevel1=wflvl1)
+        user_url = reverse('user-detail', kwargs={'pk': self.tola_user.user.id},
+                           request=self.request_post)
+
+        # create stakeholder via POST request
+        data = {'workflowlevel1': [
+            'http://testserver/api/workflowlevel1/%s/' % wflvl1.id]}
+        self.request_post = APIRequestFactory().post(
+            '/api/stakeholder/', json.dumps(data),
+            content_type='application/json')
         self.request_post.user = self.tola_user.user
         view = StakeholderViewSet.as_view({'post': 'create'})
         response = view(self.request_post)

--- a/feed/tests/test_workflowteamview.py
+++ b/feed/tests/test_workflowteamview.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 from rest_framework.reverse import reverse
 from rest_framework.test import APIRequestFactory
 
+import json
 import factories
 from feed.views import WorkflowTeamViewSet
 from workflow.models import (WorkflowTeam, ROLE_ORGANIZATION_ADMIN,
@@ -256,6 +257,36 @@ class WorkflowTeamCreateViewsTest(TestCase):
             role=role,
         )
 
+    def test_create_workflowteam_program_admin_json(self):
+        WorkflowTeam.objects.create(
+            workflow_user=self.tola_user, workflowlevel1=self.wflvl1,
+            role=factories.Group(name=ROLE_PROGRAM_ADMIN))
+
+        wflvl1_url = reverse('workflowlevel1-detail',
+                             kwargs={'pk': self.wflvl1.id})
+        tolauser_url = reverse('tolauser-detail',
+                               kwargs={'pk': self.tola_user.id})
+        role = factories.Group(name=ROLE_ORGANIZATION_ADMIN)
+        role_url = reverse('group-detail', kwargs={'pk': role.id})
+        data = {
+            'role': role_url,
+            'workflow_user': tolauser_url,
+            'workflowlevel1': wflvl1_url,
+        }
+
+        request = self.factory.post(None, json.dumps(data),
+                                    content_type='application/json')
+        request.user = self.tola_user.user
+        view = WorkflowTeamViewSet.as_view({'post': 'create'})
+        response = view(request)
+        self.assertEqual(response.status_code, 201)
+
+        WorkflowTeam.objects.get(
+            workflowlevel1=self.wflvl1,
+            workflow_user=self.tola_user,
+            role=role,
+        )
+
     def test_create_workflowteam_other_user(self):
         role_without_benefits = ROLE_PROGRAM_TEAM
         WorkflowTeam.objects.create(
@@ -349,6 +380,22 @@ class WorkflowTeamUpdateViewsTest(TestCase):
 
         data = {'salary': '100'}
         request = self.factory.post(None, data)
+        request.user = self.tola_user.user
+        view = WorkflowTeamViewSet.as_view({'post': 'update'})
+        response = view(request, pk=self.workflowteam.pk)
+        self.assertEqual(response.status_code, 200)
+
+        salary_updated = WorkflowTeam.objects.\
+            values_list('salary', flat=True).get(pk=self.workflowteam.pk)
+        self.assertEqual(salary_updated, '100')
+
+    def test_update_workflowteam_program_admin_json(self):
+        self.workflowteam.role = factories.Group(name=ROLE_PROGRAM_ADMIN)
+        self.workflowteam.save()
+
+        data = {'salary': '100'}
+        request = self.factory.post(None, json.dumps(data),
+                                    content_type='application/json')
         request.user = self.tola_user.user
         view = WorkflowTeamViewSet.as_view({'post': 'update'})
         response = view(request, pk=self.workflowteam.pk)


### PR DESCRIPTION
## Purpose
When sending raw data like JSON, we were getting an error because of the data structure. This PR includes the fix and updates for all the tests that create or update data via API.

No ticket related.