### PR TITLE
Set maintenance page if migrations cannot be run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN pip install -r requirements.txt
 
 EXPOSE 8000
 
-CMD ["sh", "-c", "python manage.py migrate && gunicorn -b 0.0.0.0:8000 tola.wsgi"]
+ENTRYPOINT ["/code/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+echo "Migrate"
+python manage.py migrate
+
+RESULT=$?
+if [ $RESULT -eq 0 ]; then
+    echo "Running the server"
+    gunicorn -b 0.0.0.0:8000 tola.wsgi
+else
+    pushd templates2/maintenance/; python -m SimpleHTTPServer 8000; popd
+fi

--- a/templates2/maintenance/index.html
+++ b/templates2/maintenance/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Maintenance page | TolaData</title>
+    <style>
+        body { text-align: center; padding: 150px; }
+        h1 { font-size: 50px; }
+        body { font: 20px Helvetica, sans-serif; color: #333; }
+        article { display: block; text-align: left; width: 650px; margin: 0 auto; }
+        a { color: #dc8100; text-decoration: none; }
+        a:hover { color: #333; text-decoration: none; }
+    </style>
+</head>
+<body>
+    <article>
+        <h1>We&rsquo;ll be back soon!</h1>
+        <div>
+            <p>Sorry for the inconvenience but we&rsquo;re performing some maintenance at the moment. If you need to you can always <a href="mailto:info@humanitec.com">contact us</a>, otherwise we&rsquo;ll be back online shortly!</p>
+            <p>&mdash; TolaData Team</p>
+        </div>
+    </article>
+</body>
+</html>


### PR DESCRIPTION
Description
=====

At the moment, if the run migrations command exits with a code different than 0, then the server tries to start, exiting also with an error code and making Marathon to try again in a infinite loop to have the service working.

Purpose
======

If migrations could not be run, we display a static maintenance page, so we allow the developer to ssh into the server having the database problem and solve the issues there.