### PR TITLE
Fix django-debug-toolbar on dev env

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 
-django-debug-toolbar==1.8
+django-debug-toolbar==1.9
 factory_boy==2.9.2

--- a/tola/settings/base.py
+++ b/tola/settings/base.py
@@ -165,9 +165,11 @@ TEMPLATES = [
 
 ########## MIDDLEWARE CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#middleware-classes
-MIDDLEWARE= (
-    # Default Django middleware.
+MIDDLEWARE = (
+    # CorsMiddleware needs to come before Django's CommonMiddleware
     'corsheaders.middleware.CorsMiddleware',
+
+    # Default Django middleware.
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'tola.middleware.DisableCsrfCheck',
@@ -181,7 +183,7 @@ MIDDLEWARE= (
     'tola.middleware.TolaSecurityMiddleware',
     'oauth2_provider.middleware.OAuth2TokenMiddleware',
     'social_django.middleware.SocialAuthExceptionMiddleware',
-    'tola.middleware.TolaRedirectMiddleware'
+    'tola.middleware.TolaRedirectMiddleware',
 )
 ########## END MIDDLEWARE CONFIGURATION
 

--- a/tola/settings/dev.py
+++ b/tola/settings/dev.py
@@ -1,5 +1,5 @@
-from os.path import join, normpath
 from local import *
+
 
 DEV_APPS = (
     'debug_toolbar',
@@ -13,7 +13,12 @@ DEV_MIDDLEWARE = (
 
 MIDDLEWARE = MIDDLEWARE + DEV_MIDDLEWARE
 
+DEBUG_TOOLBAR_CONFIG = {
+    "SHOW_TOOLBAR_CALLBACK": lambda request: True,
+}
+
 OFFLINE_MODE = True
+INTERNAL_IPS = ('127.0.0.1',)
 
 EMAIL_BACKEND = 'django.core.mail.backends.filebased.EmailBackend'
 EMAIL_FILE_PATH = '/tmp/tola-messages'

--- a/tola/urls.py
+++ b/tola/urls.py
@@ -10,7 +10,7 @@ from django.conf.urls.static import static
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from rest_framework.authtoken import views as auth_views
 from django.contrib.auth import views as authviews
-from django.contrib.auth import forms as authforms
+
 
 # Uncomment the next two lines to enable the admin:
 from django.contrib import admin
@@ -158,3 +158,13 @@ urlpatterns = [ # rest framework
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 urlpatterns += staticfiles_urlpatterns()
+
+if settings.DEBUG:
+    try:
+        import debug_toolbar
+    except ImportError:
+        pass
+    else:
+        urlpatterns = [
+            url(r'^__debug__/', include(debug_toolbar.urls)),
+        ] + urlpatterns


### PR DESCRIPTION
Purpose
=====

Fixes the broken django-debug-toolbar for Development.

![image](https://user-images.githubusercontent.com/23944/32941645-b973e4bc-cb86-11e7-9e37-8ba97c277ebc.png)
