### PR TITLE
Update endpoint filters

### DIFF
--- a/factories/__init__.py
+++ b/factories/__init__.py
@@ -1,3 +1,4 @@
+from factories.formlibrary_models import *
 from factories.indicators_models import *
 from factories.user_models import *
 from factories.workflow_models import *

--- a/factories/formlibrary_models.py
+++ b/factories/formlibrary_models.py
@@ -1,0 +1,34 @@
+from factory import DjangoModelFactory, post_generation, SubFactory
+
+from formlibrary.models import (
+    Beneficiary as BeneficiaryM,
+    CustomForm as CustomFormM
+)
+from .workflow_models import (Organization,)
+
+
+class Beneficiary(DjangoModelFactory):
+    class Meta:
+        model = BeneficiaryM
+
+    beneficiary_name = 'Julian Lennon'
+    father_name = 'John Lennon'
+
+    @post_generation
+    def workflowlevel1(self, create, extracted, **kwargs):
+        if not create:
+            # Simple build, do nothing.
+            return
+
+        if extracted:
+            # A list of workflowlevel1 were passed in, use them
+            for workflowlevel1 in extracted:
+                self.workflowlevel1.add(workflowlevel1)
+
+
+class CustomForm(DjangoModelFactory):
+    class Meta:
+        model = CustomFormM
+
+    name = 'Custom Form A'
+    organization = SubFactory(Organization)

--- a/factories/indicators_models.py
+++ b/factories/indicators_models.py
@@ -2,10 +2,13 @@ from factory import DjangoModelFactory, post_generation, SubFactory
 
 from indicators.models import (
     CollectedData as CollectedDataM,
+    ExternalService as ExternalServiceM,
     Frequency as FrequencyM,
     Indicator as IndicatorM,
+    IndicatorType as IndicatorTypeM,
     Level as LevelM,
     Objective as ObjectiveM,
+    StrategicObjective as StrategicObjectiveM,
 )
 from .workflow_models import (Organization, WorkflowLevel1)
 
@@ -58,3 +61,25 @@ class CollectedData(DjangoModelFactory):
 
     workflowlevel1 = SubFactory(WorkflowLevel1)
     indicator = SubFactory(Indicator)
+
+
+class IndicatorType(DjangoModelFactory):
+    class Meta:
+        model = IndicatorTypeM
+
+    indicator_type = 'Indicator Type A'
+
+
+class ExternalService(DjangoModelFactory):
+    class Meta:
+        model = ExternalServiceM
+
+    name = 'External Service A'
+    organization = SubFactory(Organization)
+
+
+class StrategicObjective(DjangoModelFactory):
+    class Meta:
+        model = StrategicObjectiveM
+
+    name = 'Strategic Objective A'

--- a/factories/workflow_models.py
+++ b/factories/workflow_models.py
@@ -4,13 +4,24 @@ from factory import DjangoModelFactory, lazy_attribute, LazyAttribute, \
 
 from workflow.models import (
     ApprovalType as ApprovalTypeM,
+    Award as AwardM,
+    Budget as BudgetM,
+    Checklist as ChecklistM,
+    CodedField as CodedFieldM,
     Contact as ContactM,
     Country as CountryM,
     Documentation as DocumentationM,
+    FundCode as FundCodeM,
+    IssueRegister as IssueRegisterM,
+    Milestone as MilestoneM,
     Organization as OrganizationM,
     Portfolio as PortfolioM,
+    ProfileType as ProfileTypeM,
+    ProjectType as ProjectTypeM,
     Sector as SectorM,
     SiteProfile as SiteProfileM,
+    Stakeholder as StakeholderM,
+    StakeholderType as StakeholderTypeM,
     TolaUser as TolaUserM,
     WorkflowTeam as WorkflowTeamM,
     WorkflowLevel1 as WorkflowLevel1M,
@@ -19,11 +30,26 @@ from workflow.models import (
 from .user_models import User, Group
 
 
+class Award(DjangoModelFactory):
+    class Meta:
+        model = AwardM
+
+    name = 'Award A'
+    status = 'open'
+
+
 class ApprovalType(DjangoModelFactory):
     class Meta:
         model = ApprovalTypeM
 
     name = 'Approval Type A'
+
+
+class Budget(DjangoModelFactory):
+    class Meta:
+        model = BudgetM
+
+    contributor = 'John Lennon'
 
 
 class Country(DjangoModelFactory):
@@ -76,6 +102,19 @@ class WorkflowLevel1(DjangoModelFactory):
 
     name = 'Health and Survival for Syrians in Affected Regions'
 
+    @post_generation
+    def country(self, create, extracted, **kwargs):
+        if not create:
+            # Simple build, do nothing.
+            return
+
+        if extracted:
+            # A list of country were passed in, use them
+            for country in extracted:
+                self.country.add(country)
+        else:
+            self.country.add(Country(country='Syria', code='SY'))
+
 
 class WorkflowTeam(DjangoModelFactory):
     class Meta:
@@ -112,6 +151,55 @@ class Sector(DjangoModelFactory):
     sector = 'Basic Needs'
 
 
+class Stakeholder(DjangoModelFactory):
+    class Meta:
+        model = StakeholderM
+
+    name = 'Stakeholder A'
+    organization = SubFactory(Organization)
+
+    @post_generation
+    def workflowlevel1(self, create, extracted, **kwargs):
+        if not create:
+            # Simple build, do nothing.
+            return
+
+        if extracted:
+            # A list of workflowlevel1 were passed in, use them
+            for workflowlevel1 in extracted:
+                self.workflowlevel1.add(workflowlevel1)
+
+
+class FundCode(DjangoModelFactory):
+    class Meta:
+        model = FundCodeM
+
+    name = 'Fund Code A'
+    organization = SubFactory(Organization)
+
+
+class ProjectType(DjangoModelFactory):
+    class Meta:
+        model = ProjectTypeM
+
+    name = 'Adaptive Management'
+    description = 'Adaptive Management'
+
+
+class StakeholderType(DjangoModelFactory):
+    class Meta:
+        model = StakeholderTypeM
+
+    name = 'Association'
+
+
+class ProfileType(DjangoModelFactory):
+    class Meta:
+        model = ProfileTypeM
+
+    profile = 'Distribution Center'
+
+
 class Portfolio(DjangoModelFactory):
     class Meta:
         model = PortfolioM
@@ -132,3 +220,55 @@ class Portfolio(DjangoModelFactory):
                 self.country.add(country)
         else:
             self.country.add(Country(country='Syria', code='SY'))
+
+
+class Checklist(DjangoModelFactory):
+    class Meta:
+        model = ChecklistM
+
+    name = 'Checklist A'
+
+
+class CodedField(DjangoModelFactory):
+    class Meta:
+        model = CodedFieldM
+
+    name = 'coded_field_a'
+    label = 'CodedField A'
+    organization = SubFactory(Organization)
+
+    @post_generation
+    def workflowlevel1(self, create, extracted, **kwargs):
+        if not create:
+            # Simple build, do nothing.
+            return
+
+        if extracted:
+            # A list of workflowlevel1 were passed in, use them
+            for workflowlevel1 in extracted:
+                self.workflowlevel1.add(workflowlevel1)
+
+    @post_generation
+    def workflowlevel2(self, create, extracted, **kwargs):
+        if not create:
+            # Simple build, do nothing.
+            return
+
+        if extracted:
+            # A list of workflowlevel2 were passed in, use them
+            for workflowlevel2 in extracted:
+                self.workflowlevel2.add(workflowlevel2)
+
+
+class IssueRegister(DjangoModelFactory):
+    class Meta:
+        model = IssueRegisterM
+
+    name = 'IssueRegister A'
+
+
+class Milestone(DjangoModelFactory):
+    class Meta:
+        model = MilestoneM
+
+    name = 'Design Stage'

--- a/feed/tests/test_approvaltypeview.py
+++ b/feed/tests/test_approvaltypeview.py
@@ -1,0 +1,116 @@
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
+
+import factories
+from feed.views import ApprovalTypeViewSet
+from workflow.models import WorkflowLevel1, WorkflowTeam, \
+    ROLE_ORGANIZATION_ADMIN, ROLE_PROGRAM_TEAM, ROLE_PROGRAM_ADMIN, \
+    ROLE_VIEW_ONLY
+
+
+class ApprovalTypeListViewsTest(TestCase):
+    def setUp(self):
+        factories.Organization(id=1)
+        factories.ApprovalType.create_batch(2)
+        self.factory = APIRequestFactory()
+        self.tola_user = factories.TolaUser()
+
+    def test_list_approvaltype_superuser(self):
+        request = self.factory.get('/api/approvaltype/')
+        request.user = factories.User.build(is_superuser=True,
+                                            is_staff=True)
+        view = ApprovalTypeViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 2)
+
+    def test_list_approvaltype_org_admin(self):
+        request = self.factory.get('/api/approvaltype/')
+        group_org_admin = factories.Group(name=ROLE_ORGANIZATION_ADMIN)
+        self.tola_user.user.groups.add(group_org_admin)
+
+        request.user = self.tola_user.user
+        view = ApprovalTypeViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 0)
+
+        factories.ApprovalType(organization=self.tola_user.organization)
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+
+    def test_list_approvaltype_program_admin(self):
+        request = self.factory.get('/api/approvaltype/')
+        WorkflowTeam.objects.create(
+            workflow_user=self.tola_user,
+            role=factories.Group(name=ROLE_PROGRAM_ADMIN))
+        request.user = self.tola_user.user
+        view = ApprovalTypeViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 0)
+
+        factories.ApprovalType(organization=self.tola_user.organization)
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+
+    def test_list_approvaltype_program_team(self):
+        request = self.factory.get('/api/approvaltype/')
+        WorkflowTeam.objects.create(
+            workflow_user=self.tola_user,
+            role=factories.Group(name=ROLE_PROGRAM_TEAM))
+        request.user = self.tola_user.user
+        view = ApprovalTypeViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 0)
+
+        factories.ApprovalType(organization=self.tola_user.organization)
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+
+    def test_list_approvaltype_view_only(self):
+        request = self.factory.get('/api/approvaltype/')
+        WorkflowTeam.objects.create(
+            workflow_user=self.tola_user,
+            role=factories.Group(name=ROLE_VIEW_ONLY))
+        request.user = self.tola_user.user
+        view = ApprovalTypeViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 0)
+
+        factories.ApprovalType(organization=self.tola_user.organization)
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+
+
+class ApprovalTypeFilterViewTest(TestCase):
+    def setUp(self):
+        self.tola_user = factories.TolaUser()
+        self.factory = APIRequestFactory()
+
+    def test_filter_approvaltype_superuser(self):
+        another_org = factories.Organization(name='Another Org')
+        approvaltype1_1 = factories.ApprovalType(
+            organization=self.tola_user.organization)
+        factories.ApprovalType(
+            name='Another Approval Type',
+            organization=another_org)
+
+        self.tola_user.user.is_staff = True
+        self.tola_user.user.is_superuser = True
+        self.tola_user.user.save()
+
+        request = self.factory.get('/api/approvaltype/?organization__id=%s' %
+                                   self.tola_user.organization.pk)
+        request.user = self.tola_user.user
+        view = ApprovalTypeViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], approvaltype1_1.name)

--- a/feed/tests/test_awardview.py
+++ b/feed/tests/test_awardview.py
@@ -1,135 +1,112 @@
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory
-from rest_framework.reverse import reverse
 
 import factories
-from feed.views import CustomFormViewSet
+from feed.views import AwardViewSet
 from workflow.models import WorkflowTeam, ROLE_ORGANIZATION_ADMIN, \
     ROLE_PROGRAM_TEAM, ROLE_PROGRAM_ADMIN, ROLE_VIEW_ONLY
 
 
-class CustomFormListViewsTest(TestCase):
+class AwardListViewsTest(TestCase):
     def setUp(self):
         factories.Organization(id=1)
-        factories.CustomForm.create_batch(2)
+        factories.Award.create_batch(2)
         self.factory = APIRequestFactory()
         self.tola_user = factories.TolaUser()
 
-    def test_list_customform_superuser(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_award_superuser(self):
+        request = self.factory.get('/api/award/')
         request.user = factories.User.build(is_superuser=True,
                                             is_staff=True)
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = AwardViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 2)
 
-    def test_list_customform_org_admin(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_award_org_admin(self):
+        request = self.factory.get('/api/award/')
         group_org_admin = factories.Group(name=ROLE_ORGANIZATION_ADMIN)
         self.tola_user.user.groups.add(group_org_admin)
 
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = AwardViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.Award(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
-    def test_list_customform_program_admin(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_award_program_admin(self):
+        request = self.factory.get('/api/award/')
         WorkflowTeam.objects.create(
             workflow_user=self.tola_user,
             role=factories.Group(name=ROLE_PROGRAM_ADMIN))
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = AwardViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.Award(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
-    def test_list_customform_program_team(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_award_program_team(self):
+        request = self.factory.get('/api/award/')
         WorkflowTeam.objects.create(
             workflow_user=self.tola_user,
             role=factories.Group(name=ROLE_PROGRAM_TEAM))
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = AwardViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.Award(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
-    def test_list_customform_view_only(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_award_view_only(self):
+        request = self.factory.get('/api/award/')
         WorkflowTeam.objects.create(
             workflow_user=self.tola_user,
             role=factories.Group(name=ROLE_VIEW_ONLY))
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = AwardViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.Award(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
 
-class CustomFormCreateViewTest(TestCase):
-    def setUp(self):
-        self.user = factories.User(is_superuser=True, is_staff=True)
-        self.organization = factories.Organization(id=1)
-        factories.TolaUser(user=self.user, organization=self.organization)
-        factory = APIRequestFactory()
-        self.request = factory.post('/api/customform/')
-
-    def test_create_customform(self):
-        user_url = reverse('user-detail', kwargs={'pk': self.user.id},
-                           request=self.request)
-
-        data = {'name': '4W Daily Activity Report'}
-        self.request = APIRequestFactory().post('/api/customform/', data)
-        self.request.user = self.user
-        view = CustomFormViewSet.as_view({'post': 'create'})
-        response = view(self.request)
-
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.data['name'], u'4W Daily Activity Report')
-        self.assertEqual(response.data['created_by'], user_url)
-
-
-class CustomFormFilterViewsTest(TestCase):
+class AwardFilterViewsTest(TestCase):
     def setUp(self):
         self.factory = APIRequestFactory()
         self.tola_user = factories.TolaUser()
 
-    def test_filter_customform_superuser(self):
+    def test_filter_award_superuser(self):
         self.tola_user.user.is_staff = True
         self.tola_user.user.is_superuser = True
         self.tola_user.user.save()
 
-        ext_serv1 = factories.CustomForm(
+        another_org = factories.Organization(name='Another Org')
+        award1 = factories.Award(
             organization=self.tola_user.organization)
-        factories.CustomForm(name='Custom Form B')
-        request = self.factory.get('/api/customform/?organization__id=%s' %
+        factories.Award(name='Award B', organization=another_org)
+        request = self.factory.get('/api/award/?organization__id=%s' %
                                    self.tola_user.organization.pk)
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = AwardViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
-        self.assertEqual(response.data[0]['name'], ext_serv1.name)
+        self.assertEqual(response.data[0]['name'], award1.name)

--- a/feed/tests/test_beneficiaryview.py
+++ b/feed/tests/test_beneficiaryview.py
@@ -1,135 +1,127 @@
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory
-from rest_framework.reverse import reverse
 
 import factories
-from feed.views import CustomFormViewSet
+from feed.views import BeneficiaryViewSet
 from workflow.models import WorkflowTeam, ROLE_ORGANIZATION_ADMIN, \
     ROLE_PROGRAM_TEAM, ROLE_PROGRAM_ADMIN, ROLE_VIEW_ONLY
 
 
-class CustomFormListViewsTest(TestCase):
+class BeneficiaryListViewsTest(TestCase):
     def setUp(self):
-        factories.Organization(id=1)
-        factories.CustomForm.create_batch(2)
+        factories.Beneficiary.create_batch(2)
         self.factory = APIRequestFactory()
         self.tola_user = factories.TolaUser()
 
-    def test_list_customform_superuser(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_beneficiary_superuser(self):
+        request = self.factory.get('/api/beneficiary/')
         request.user = factories.User.build(is_superuser=True,
                                             is_staff=True)
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = BeneficiaryViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 2)
 
-    def test_list_customform_org_admin(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_beneficiary_org_admin(self):
+        request = self.factory.get('/api/beneficiary/')
         group_org_admin = factories.Group(name=ROLE_ORGANIZATION_ADMIN)
         self.tola_user.user.groups.add(group_org_admin)
 
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = BeneficiaryViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        wkflvl1 = factories.WorkflowLevel1(
+            organization=self.tola_user.organization)
+        factories.Beneficiary(workflowlevel1=[wkflvl1])
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
-    def test_list_customform_program_admin(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_beneficiary_program_admin(self):
+        request = self.factory.get('/api/beneficiary/')
         WorkflowTeam.objects.create(
             workflow_user=self.tola_user,
             role=factories.Group(name=ROLE_PROGRAM_ADMIN))
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = BeneficiaryViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        wkflvl1 = factories.WorkflowLevel1(
+            organization=self.tola_user.organization)
+        factories.Beneficiary(workflowlevel1=[wkflvl1])
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
-    def test_list_customform_program_team(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_beneficiary_program_team(self):
+        request = self.factory.get('/api/beneficiary/')
         WorkflowTeam.objects.create(
             workflow_user=self.tola_user,
             role=factories.Group(name=ROLE_PROGRAM_TEAM))
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = BeneficiaryViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        wkflvl1 = factories.WorkflowLevel1(
+            organization=self.tola_user.organization)
+        factories.Beneficiary(workflowlevel1=[wkflvl1])
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
-    def test_list_customform_view_only(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_beneficiary_view_only(self):
+        request = self.factory.get('/api/beneficiary/')
         WorkflowTeam.objects.create(
             workflow_user=self.tola_user,
             role=factories.Group(name=ROLE_VIEW_ONLY))
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = BeneficiaryViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        wkflvl1 = factories.WorkflowLevel1(
+            organization=self.tola_user.organization)
+        factories.Beneficiary(workflowlevel1=[wkflvl1])
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
 
-class CustomFormCreateViewTest(TestCase):
+class BeneficiaryFilterViewTest(TestCase):
     def setUp(self):
-        self.user = factories.User(is_superuser=True, is_staff=True)
-        self.organization = factories.Organization(id=1)
-        factories.TolaUser(user=self.user, organization=self.organization)
-        factory = APIRequestFactory()
-        self.request = factory.post('/api/customform/')
-
-    def test_create_customform(self):
-        user_url = reverse('user-detail', kwargs={'pk': self.user.id},
-                           request=self.request)
-
-        data = {'name': '4W Daily Activity Report'}
-        self.request = APIRequestFactory().post('/api/customform/', data)
-        self.request.user = self.user
-        view = CustomFormViewSet.as_view({'post': 'create'})
-        response = view(self.request)
-
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.data['name'], u'4W Daily Activity Report')
-        self.assertEqual(response.data['created_by'], user_url)
-
-
-class CustomFormFilterViewsTest(TestCase):
-    def setUp(self):
-        self.factory = APIRequestFactory()
         self.tola_user = factories.TolaUser()
+        self.factory = APIRequestFactory()
 
-    def test_filter_customform_superuser(self):
+    def test_filter_beneficiary_superuser(self):
         self.tola_user.user.is_staff = True
         self.tola_user.user.is_superuser = True
         self.tola_user.user.save()
 
-        ext_serv1 = factories.CustomForm(
+        another_org = factories.Organization(name='Another Org')
+        wkflvl1_1 = factories.WorkflowLevel1(
             organization=self.tola_user.organization)
-        factories.CustomForm(name='Custom Form B')
-        request = self.factory.get('/api/customform/?organization__id=%s' %
-                                   self.tola_user.organization.pk)
+        wkflvl1_2 = factories.WorkflowLevel1(
+            organization=another_org)
+        beneficiary1 = factories.Beneficiary(workflowlevel1=[wkflvl1_1])
+        factories.Beneficiary(
+            beneficiary_name='James McCartney', father_name='Paul McCartney',
+            workflowlevel1=[wkflvl1_2])
+
+        request = self.factory.get(
+            '/api/beneficiary/?workflowlevel1__organization__id=%s' %
+            self.tola_user.organization.pk)
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = BeneficiaryViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
-        self.assertEqual(response.data[0]['name'], ext_serv1.name)
+        self.assertEqual(response.data[0]['beneficiary_name'],
+                         beneficiary1.beneficiary_name)

--- a/feed/tests/test_checklistview.py
+++ b/feed/tests/test_checklistview.py
@@ -4,13 +4,15 @@ from rest_framework.test import APIRequestFactory
 
 import factories
 from feed.views import ChecklistViewSet
-from workflow.models import Checklist, WorkflowLevel1, WorkflowLevel2
+from workflow.models import Checklist, WorkflowLevel1, WorkflowLevel2, \
+    WorkflowTeam, ROLE_ORGANIZATION_ADMIN
 
 
-class ChecklistViewsTest(TestCase):
+class ChecklistListViewTest(TestCase):
     def setUp(self):
         wflvl1 = WorkflowLevel1.objects.create(name='WorkflowLevel1')
-        wflvl2 = WorkflowLevel2.objects.create(name='WorkflowLevel2', workflowlevel1=wflvl1)
+        wflvl2 = WorkflowLevel2.objects.create(name='WorkflowLevel2',
+                                               workflowlevel1=wflvl1)
         Checklist.objects.bulk_create([
             Checklist(name='CheckList_0', workflowlevel2=wflvl2),
             Checklist(name='CheckList_1', workflowlevel2=wflvl2),
@@ -20,7 +22,8 @@ class ChecklistViewsTest(TestCase):
         self.request = factory.get('/api/checklist/')
 
     def test_list_checklist_superuser(self):
-        self.request.user = factories.User.build(is_superuser=True, is_staff=True)
+        self.request.user = factories.User.build(is_superuser=True,
+                                                 is_staff=True)
         view = ChecklistViewSet.as_view({'get': 'list'})
         response = view(self.request)
         self.assertEqual(response.status_code, 200)
@@ -36,8 +39,10 @@ class ChecklistViewsTest(TestCase):
 
     def test_list_checklist_normaluser_one_result(self):
         tola_user = factories.TolaUser()
-        wflvl1 = WorkflowLevel1.objects.create(name='WorkflowLevel1', organization=tola_user.organization)
-        wflvl2 = WorkflowLevel2.objects.create(name='WorkflowLevel2', workflowlevel1=wflvl1)
+        wflvl1 = WorkflowLevel1.objects.create(
+            name='WorkflowLevel1', organization=tola_user.organization)
+        wflvl2 = WorkflowLevel2.objects.create(name='WorkflowLevel2',
+                                               workflowlevel1=wflvl1)
         Checklist.objects.create(name='CheckList_0', workflowlevel2=wflvl2)
 
         self.request.user = tola_user.user
@@ -45,3 +50,122 @@ class ChecklistViewsTest(TestCase):
         response = view(self.request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
+
+
+class ChecklistFilterViewTest(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.tola_user = factories.TolaUser()
+
+    def test_filter_checklist_org_superuser(self):
+        self.tola_user.user.is_staff = True
+        self.tola_user.user.is_superuser = True
+        self.tola_user.user.save()
+
+        another_org = factories.Organization(name='Another Org')
+        wkflvl1_1 = factories.WorkflowLevel1(
+            organization=self.tola_user.organization)
+        wkflvl1_2 = factories.WorkflowLevel1(organization=another_org)
+        wkflvl2_1 = factories.WorkflowLevel2(workflowlevel1=wkflvl1_1)
+        wkflvl2_2 = factories.WorkflowLevel2(workflowlevel1=wkflvl1_2)
+        checklist1 = factories.Checklist(name='Checklist A',
+                                         workflowlevel2=wkflvl2_1)
+        factories.Checklist(name='Checklist B',
+                                         workflowlevel2=wkflvl2_2)
+
+        request = self.factory.get(
+            '/api/checklist/?workflowlevel2__workflowlevel1__organization__id'
+            '=%s' % self.tola_user.organization.pk)
+        request.user = self.tola_user.user
+        view = ChecklistViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], checklist1.name)
+
+    def test_filter_checklist_country_org_admin(self):
+        group_org_admin = factories.Group(name=ROLE_ORGANIZATION_ADMIN)
+        self.tola_user.user.groups.add(group_org_admin)
+
+        country1 = factories.Country(country='Brazil', code='BR')
+        country2 = factories.Country(country='Germany', code='DE')
+        wkflvl1_1 = factories.WorkflowLevel1(
+            organization=self.tola_user.organization, country=[country1])
+        wkflvl1_2 = factories.WorkflowLevel1(
+            organization=self.tola_user.organization, country=[country2])
+        wkflvl2_1 = factories.WorkflowLevel2(workflowlevel1=wkflvl1_1)
+        wkflvl2_2 = factories.WorkflowLevel2(workflowlevel1=wkflvl1_2)
+        checklist1 = factories.Checklist(name='Checklist A',
+                                         workflowlevel2=wkflvl2_1)
+        factories.Checklist(name='Checklist B',
+                                         workflowlevel2=wkflvl2_2)
+
+        request = self.factory.get(
+            '/api/checklist'
+            '/?workflowlevel2__workflowlevel1__country__country=%s'
+            % country1.country)
+        request.user = self.tola_user.user
+        view = ChecklistViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], checklist1.name)
+
+    def test_filter_checklist_wkflvl2_name_org_admin(self):
+        group_org_admin = factories.Group(name=ROLE_ORGANIZATION_ADMIN)
+        self.tola_user.user.groups.add(group_org_admin)
+
+        wkflvl1_1 = factories.WorkflowLevel1(
+            organization=self.tola_user.organization)
+        wkflvl1_2 = factories.WorkflowLevel1(
+            organization=self.tola_user.organization)
+        wkflvl2_1 = factories.WorkflowLevel2(
+            name='WorkflowLevel2 A', workflowlevel1=wkflvl1_1)
+        wkflvl2_2 = factories.WorkflowLevel2(
+            name='WorkflowLevel2 B', workflowlevel1=wkflvl1_2)
+        checklist1 = factories.Checklist(
+            name='Checklist A', workflowlevel2=wkflvl2_1)
+        factories.Checklist(
+            name='Checklist B', workflowlevel2=wkflvl2_2)
+
+        request = self.factory.get(
+            '/api/checklist'
+            '/?workflowlevel2__name=%s'
+            % wkflvl2_1.name)
+        request.user = self.tola_user.user
+        view = ChecklistViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], checklist1.name)
+
+    def test_filter_checklist_owner_org_admin(self):
+        group_org_admin = factories.Group(name=ROLE_ORGANIZATION_ADMIN)
+        self.tola_user.user.groups.add(group_org_admin)
+
+        another_user = factories.User(first_name='Johnn', last_name='Lennon')
+        another_tola = factories.TolaUser(user=another_user)
+        wkflvl1_1 = factories.WorkflowLevel1(
+            organization=self.tola_user.organization)
+        wkflvl1_2 = factories.WorkflowLevel1(
+            organization=self.tola_user.organization)
+        wkflvl2_1 = factories.WorkflowLevel2(
+            name='WorkflowLevel2 A', workflowlevel1=wkflvl1_1)
+        wkflvl2_2 = factories.WorkflowLevel2(
+            name='WorkflowLevel2 B', workflowlevel1=wkflvl1_2)
+        checklist1 = factories.Checklist(
+            name='Checklist A', owner=self.tola_user, workflowlevel2=wkflvl2_1)
+        factories.Checklist(
+            name='Checklist B', owner=another_tola, workflowlevel2=wkflvl2_2)
+
+        request = self.factory.get(
+            '/api/checklist'
+            '/?owner=%s'
+            % self.tola_user.pk)
+        request.user = self.tola_user.user
+        view = ChecklistViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], checklist1.name)
+

--- a/feed/tests/test_codedfieldview.py
+++ b/feed/tests/test_codedfieldview.py
@@ -1,76 +1,69 @@
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory
-from rest_framework.reverse import reverse
 
 import factories
-from feed.views import BudgetViewSet
+from feed.views import CodedFieldViewSet
 
 
-class BudgetListViewTest(TestCase):
+class CodedFieldListViewTest(TestCase):
     def setUp(self):
+        factories.Organization(id=1)
         wflvl1 = factories.WorkflowLevel1()
         wflvl2 = factories.WorkflowLevel2(name='WorkflowLevel2',
                                           workflowlevel1=wflvl1)
-        factories.Budget.create_batch(2, workflowlevel2=wflvl2)
+        factories.CodedField.create_batch(2, workflowlevel2=[wflvl2])
 
         factory = APIRequestFactory()
-        self.request = factory.get('/api/budget/')
+        self.request = factory.get('/api/codedfield/')
 
-    def test_list_budget_superuser(self):
+    def test_list_codedfield_superuser(self):
         self.request.user = factories.User.build(is_superuser=True,
                                                  is_staff=True)
-        view = BudgetViewSet.as_view({'get': 'list'})
+        view = CodedFieldViewSet.as_view({'get': 'list'})
         response = view(self.request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 2)
 
-    def test_list_budget_normaluser(self):
+    def test_list_codedfield_normaluser(self):
         tola_user = factories.TolaUser()
         self.request.user = tola_user.user
-        view = BudgetViewSet.as_view({'get': 'list'})
+        view = CodedFieldViewSet.as_view({'get': 'list'})
         response = view(self.request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-    def test_list_budget_normaluser_one_result(self):
+    def test_list_codedfield_normaluser_one_result(self):
         tola_user = factories.TolaUser()
-        wflvl1 = factories.WorkflowLevel1(
-            name='WorkflowLevel1', organization=tola_user.organization)
-        wflvl2 = factories.WorkflowLevel2(
-            name='WorkflowLevel2', workflowlevel1=wflvl1)
-        factories.Budget(workflowlevel2=wflvl2)
+        factories.CodedField(organization=tola_user.organization)
 
         self.request.user = tola_user.user
-        view = BudgetViewSet.as_view({'get': 'list'})
+        view = CodedFieldViewSet.as_view({'get': 'list'})
         response = view(self.request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
 
-class BudgetCreateViewTest(TestCase):
+class CodedFieldCreateViewTest(TestCase):
     def setUp(self):
         self.user = factories.User(is_superuser=True, is_staff=True)
         factory = APIRequestFactory()
-        self.request = factory.post('/api/budget/')
+        self.request = factory.post('/api/codedfield/')
 
-    def test_create_budget(self):
-        user_url = reverse('user-detail', kwargs={'pk': self.user.id},
-                           request=self.request)
-
+    def test_create_codedfield(self):
+        factories.Organization(id=1)
         self.request.user = self.user
-        view = BudgetViewSet.as_view({'post': 'create'})
+        view = CodedFieldViewSet.as_view({'post': 'create'})
         response = view(self.request)
 
         self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.data['created_by'], user_url)
 
 
-class BudgetFilterViewTest(TestCase):
+class CodedFieldFilterViewTest(TestCase):
     def setUp(self):
         self.factory = APIRequestFactory()
         self.tola_user = factories.TolaUser()
 
-    def test_filter_budget_org_superuser(self):
+    def test_filter_codedfield_org_superuser(self):
         self.tola_user.user.is_staff = True
         self.tola_user.user.is_superuser = True
         self.tola_user.user.save()
@@ -81,15 +74,15 @@ class BudgetFilterViewTest(TestCase):
         wkflvl1_2 = factories.WorkflowLevel1(organization=another_org)
         wkflvl2_1 = factories.WorkflowLevel2(workflowlevel1=wkflvl1_1)
         wkflvl2_2 = factories.WorkflowLevel2(workflowlevel1=wkflvl1_2)
-        budget1 = factories.Budget(workflowlevel2=wkflvl2_1)
-        factories.Budget(contributor='Paul McCartney', workflowlevel2=wkflvl2_2)
+        codedfield1 = factories.CodedField(workflowlevel2=[wkflvl2_1])
+        factories.CodedField(name='coded_field_b', workflowlevel2=[wkflvl2_2])
 
         request = self.factory.get(
-            '/api/budget/?workflowlevel2__workflowlevel1__organization__id'
+            '/api/codedfield/?workflowlevel2__workflowlevel1__organization__id'
             '=%s' % self.tola_user.organization.pk)
         request.user = self.tola_user.user
-        view = BudgetViewSet.as_view({'get': 'list'})
+        view = CodedFieldViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
-        self.assertEqual(response.data[0]['contributor'], budget1.contributor)
+        self.assertEqual(response.data[0]['name'], codedfield1.name)

--- a/feed/tests/test_documentationview.py
+++ b/feed/tests/test_documentationview.py
@@ -10,7 +10,7 @@ from workflow.models import Documentation, WorkflowLevel1, WorkflowTeam, \
     ROLE_VIEW_ONLY
 
 
-class DocumentationViewsTest(TestCase):
+class DocumentationListViewTest(TestCase):
     def setUp(self):
         factories.Documentation.create_batch(2)
         self.factory = APIRequestFactory()
@@ -47,6 +47,12 @@ class DocumentationViewsTest(TestCase):
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
+
+
+class DocumentationCreateViewTest(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.tola_user = factories.TolaUser()
 
     def test_create_documentation_org_admin(self):
         group_org_admin = factories.Group(name=ROLE_ORGANIZATION_ADMIN)
@@ -110,6 +116,12 @@ class DocumentationViewsTest(TestCase):
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.data['workflowlevel1'], wflvl1_url)
+
+
+class DocumentationDeleteViewTest(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.tola_user = factories.TolaUser()
 
     def test_delete_documentation_non_existing(self):
         request = self.factory.delete('/api/documentation/')
@@ -206,3 +218,83 @@ class DocumentationViewsTest(TestCase):
         response = view(request, pk=documentation.pk)
         self.assertEquals(response.status_code, 403)
         Documentation.objects.get(pk=documentation.pk)
+
+
+class DocumentationFilterViewTest(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.tola_user = factories.TolaUser()
+
+    def test_filter_documentation_country_superuser(self):
+        self.tola_user.user.is_staff = True
+        self.tola_user.user.is_superuser = True
+        self.tola_user.user.save()
+
+        wflvl1_1 = factories.WorkflowLevel1(
+            name='WorkflowLevel1_1',
+            organization=self.tola_user.organization)
+        wflvl2_1 = factories.WorkflowLevel2(workflowlevel1=wflvl1_1)
+        WorkflowTeam.objects.create(workflow_user=self.tola_user,
+                                    workflowlevel1=wflvl1_1)
+        documentation1 = factories.Documentation(name='Document 1',
+                                                 workflowlevel1=wflvl1_1,
+                                                 workflowlevel2=wflvl2_1)
+
+        another_org = factories.Organization(name='Another Org')
+        wflvl1_2 = factories.WorkflowLevel1(
+            name='WorkflowLevel1_2',
+            organization=another_org)
+        wflvl2_2 = factories.WorkflowLevel2(workflowlevel1=wflvl1_2)
+        WorkflowTeam.objects.create(workflow_user=self.tola_user,
+                                    workflowlevel1=wflvl1_2)
+        factories.Documentation(name='Document 2', workflowlevel1=wflvl1_2,
+                                workflowlevel2=wflvl2_2)
+
+        request = self.factory.get(
+            '/api/documentation'
+            '/?workflowlevel2__workflowlevel1__organization__id=%s' %
+            self.tola_user.organization.pk)
+        request.user = self.tola_user.user
+        view = DocumentationViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], documentation1.name)
+
+    def test_filter_documentation_org_org_admin(self):
+        group_org_admin = factories.Group(name=ROLE_ORGANIZATION_ADMIN)
+        self.tola_user.user.groups.add(group_org_admin)
+
+        country1 = factories.Country()
+        wflvl1_1 = factories.WorkflowLevel1(
+            name='WorkflowLevel1_1',
+            country=[country1],
+            organization=self.tola_user.organization)
+        wflvl2_1 = factories.WorkflowLevel2(workflowlevel1=wflvl1_1)
+        WorkflowTeam.objects.create(workflow_user=self.tola_user,
+                                    workflowlevel1=wflvl1_1)
+        documentation1 = factories.Documentation(name='Document 1',
+                                                 workflowlevel1=wflvl1_1,
+                                                 workflowlevel2=wflvl2_1)
+
+        country2 = factories.Country(country='Brazil', code='BR')
+        wflvl1_2 = factories.WorkflowLevel1(
+            name='WorkflowLevel1_2',
+            country=[country2],
+            organization=self.tola_user.organization)
+        wflvl2_2 = factories.WorkflowLevel2(workflowlevel1=wflvl1_2)
+        WorkflowTeam.objects.create(workflow_user=self.tola_user,
+                                    workflowlevel1=wflvl1_2)
+        factories.Documentation(name='Document 2', workflowlevel1=wflvl1_2,
+                                workflowlevel2=wflvl2_2)
+
+        request = self.factory.get(
+            '/api/documentation'
+            '/?workflowlevel2__workflowlevel1__country__country=%s' %
+            country1.country)
+        request.user = self.tola_user.user
+        view = DocumentationViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], documentation1.name)

--- a/feed/tests/test_externalserviceview.py
+++ b/feed/tests/test_externalserviceview.py
@@ -1,134 +1,110 @@
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory
-from rest_framework.reverse import reverse
 
 import factories
-from feed.views import CustomFormViewSet
+from feed.views import ExternalServiceViewSet
 from workflow.models import WorkflowTeam, ROLE_ORGANIZATION_ADMIN, \
     ROLE_PROGRAM_TEAM, ROLE_PROGRAM_ADMIN, ROLE_VIEW_ONLY
 
 
-class CustomFormListViewsTest(TestCase):
+class ExternalServiceListViewsTest(TestCase):
     def setUp(self):
         factories.Organization(id=1)
-        factories.CustomForm.create_batch(2)
+        factories.ExternalService.create_batch(2)
         self.factory = APIRequestFactory()
         self.tola_user = factories.TolaUser()
 
-    def test_list_customform_superuser(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_externalservice_superuser(self):
+        request = self.factory.get('/api/externalservice/')
         request.user = factories.User.build(is_superuser=True,
                                             is_staff=True)
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = ExternalServiceViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 2)
 
-    def test_list_customform_org_admin(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_externalservice_org_admin(self):
+        request = self.factory.get('/api/externalservice/')
         group_org_admin = factories.Group(name=ROLE_ORGANIZATION_ADMIN)
         self.tola_user.user.groups.add(group_org_admin)
 
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = ExternalServiceViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.ExternalService(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
-    def test_list_customform_program_admin(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_externalservice_program_admin(self):
+        request = self.factory.get('/api/externalservice/')
         WorkflowTeam.objects.create(
             workflow_user=self.tola_user,
             role=factories.Group(name=ROLE_PROGRAM_ADMIN))
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = ExternalServiceViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.ExternalService(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
-    def test_list_customform_program_team(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_externalservice_program_team(self):
+        request = self.factory.get('/api/externalservice/')
         WorkflowTeam.objects.create(
             workflow_user=self.tola_user,
             role=factories.Group(name=ROLE_PROGRAM_TEAM))
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = ExternalServiceViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.ExternalService(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
-    def test_list_customform_view_only(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_externalservice_view_only(self):
+        request = self.factory.get('/api/externalservice/')
         WorkflowTeam.objects.create(
             workflow_user=self.tola_user,
             role=factories.Group(name=ROLE_VIEW_ONLY))
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = ExternalServiceViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.ExternalService(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
 
-class CustomFormCreateViewTest(TestCase):
-    def setUp(self):
-        self.user = factories.User(is_superuser=True, is_staff=True)
-        self.organization = factories.Organization(id=1)
-        factories.TolaUser(user=self.user, organization=self.organization)
-        factory = APIRequestFactory()
-        self.request = factory.post('/api/customform/')
-
-    def test_create_customform(self):
-        user_url = reverse('user-detail', kwargs={'pk': self.user.id},
-                           request=self.request)
-
-        data = {'name': '4W Daily Activity Report'}
-        self.request = APIRequestFactory().post('/api/customform/', data)
-        self.request.user = self.user
-        view = CustomFormViewSet.as_view({'post': 'create'})
-        response = view(self.request)
-
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.data['name'], u'4W Daily Activity Report')
-        self.assertEqual(response.data['created_by'], user_url)
-
-
-class CustomFormFilterViewsTest(TestCase):
+class ExternalServiceFilterViewsTest(TestCase):
     def setUp(self):
         self.factory = APIRequestFactory()
         self.tola_user = factories.TolaUser()
 
-    def test_filter_customform_superuser(self):
+    def test_filter_externalservice_superuser(self):
         self.tola_user.user.is_staff = True
         self.tola_user.user.is_superuser = True
         self.tola_user.user.save()
 
-        ext_serv1 = factories.CustomForm(
+        ext_serv1 = factories.ExternalService(
             organization=self.tola_user.organization)
-        factories.CustomForm(name='Custom Form B')
-        request = self.factory.get('/api/customform/?organization__id=%s' %
+        factories.ExternalService(name='External Service B')
+        request = self.factory.get('/api/externalservice/?organization__id=%s' %
                                    self.tola_user.organization.pk)
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = ExternalServiceViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)

--- a/feed/tests/test_fundcodeview.py
+++ b/feed/tests/test_fundcodeview.py
@@ -1,135 +1,132 @@
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory
-from rest_framework.reverse import reverse
 
 import factories
-from feed.views import CustomFormViewSet
+from feed.views import FundCodeViewSet
 from workflow.models import WorkflowTeam, ROLE_ORGANIZATION_ADMIN, \
     ROLE_PROGRAM_TEAM, ROLE_PROGRAM_ADMIN, ROLE_VIEW_ONLY
 
 
-class CustomFormListViewsTest(TestCase):
+class FundCodeListViewsTest(TestCase):
     def setUp(self):
         factories.Organization(id=1)
-        factories.CustomForm.create_batch(2)
+        factories.FundCode.create_batch(2)
         self.factory = APIRequestFactory()
         self.tola_user = factories.TolaUser()
 
-    def test_list_customform_superuser(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_fundcode_superuser(self):
+        request = self.factory.get('/api/fundcode/')
         request.user = factories.User.build(is_superuser=True,
                                             is_staff=True)
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = FundCodeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 2)
 
-    def test_list_customform_org_admin(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_fundcode_org_admin(self):
+        request = self.factory.get('/api/fundcode/')
         group_org_admin = factories.Group(name=ROLE_ORGANIZATION_ADMIN)
         self.tola_user.user.groups.add(group_org_admin)
 
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = FundCodeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.FundCode(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
-    def test_list_customform_program_admin(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_fundcode_program_admin(self):
+        request = self.factory.get('/api/fundcode/')
         WorkflowTeam.objects.create(
             workflow_user=self.tola_user,
             role=factories.Group(name=ROLE_PROGRAM_ADMIN))
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = FundCodeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.FundCode(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
-    def test_list_customform_program_team(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_fundcode_program_team(self):
+        request = self.factory.get('/api/fundcode/')
         WorkflowTeam.objects.create(
             workflow_user=self.tola_user,
             role=factories.Group(name=ROLE_PROGRAM_TEAM))
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = FundCodeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.FundCode(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
-    def test_list_customform_view_only(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_fundcode_view_only(self):
+        request = self.factory.get('/api/fundcode/')
         WorkflowTeam.objects.create(
             workflow_user=self.tola_user,
             role=factories.Group(name=ROLE_VIEW_ONLY))
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = FundCodeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.FundCode(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
 
-class CustomFormCreateViewTest(TestCase):
+class FundCodeFilterViewTest(TestCase):
     def setUp(self):
-        self.user = factories.User(is_superuser=True, is_staff=True)
-        self.organization = factories.Organization(id=1)
-        factories.TolaUser(user=self.user, organization=self.organization)
-        factory = APIRequestFactory()
-        self.request = factory.post('/api/customform/')
-
-    def test_create_customform(self):
-        user_url = reverse('user-detail', kwargs={'pk': self.user.id},
-                           request=self.request)
-
-        data = {'name': '4W Daily Activity Report'}
-        self.request = APIRequestFactory().post('/api/customform/', data)
-        self.request.user = self.user
-        view = CustomFormViewSet.as_view({'post': 'create'})
-        response = view(self.request)
-
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.data['name'], u'4W Daily Activity Report')
-        self.assertEqual(response.data['created_by'], user_url)
-
-
-class CustomFormFilterViewsTest(TestCase):
-    def setUp(self):
-        self.factory = APIRequestFactory()
         self.tola_user = factories.TolaUser()
+        self.factory = APIRequestFactory()
 
-    def test_filter_customform_superuser(self):
+    def test_filter_fundcode_superuser(self):
+        another_org = factories.Organization(name='Another Org')
+        fundcode1_1 = factories.FundCode(
+            organization=self.tola_user.organization)
+        factories.FundCode(
+            name='Another FundCode',
+            organization=another_org)
+
         self.tola_user.user.is_staff = True
         self.tola_user.user.is_superuser = True
         self.tola_user.user.save()
 
-        ext_serv1 = factories.CustomForm(
-            organization=self.tola_user.organization)
-        factories.CustomForm(name='Custom Form B')
-        request = self.factory.get('/api/customform/?organization__id=%s' %
+        request = self.factory.get('/api/fundcode/?organization__id=%s' %
                                    self.tola_user.organization.pk)
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = FundCodeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
-        self.assertEqual(response.data[0]['name'], ext_serv1.name)
+        self.assertEqual(response.data[0]['name'], fundcode1_1.name)
+
+    def test_filter_fundcode_normaluser(self):
+        another_org = factories.Organization(name='Another Org')
+        fundcode1_1 = factories.FundCode(
+            organization=self.tola_user.organization)
+        factories.FundCode(
+            name='Another FundCode',
+            organization=another_org)
+
+        request = self.factory.get('/api/fundcode/?organization__id=%s' %
+                                   self.tola_user.organization.pk)
+        request.user = self.tola_user.user
+        view = FundCodeViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], fundcode1_1.name)

--- a/feed/tests/test_indicatortypeview.py
+++ b/feed/tests/test_indicatortypeview.py
@@ -1,135 +1,132 @@
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory
-from rest_framework.reverse import reverse
 
 import factories
-from feed.views import CustomFormViewSet
+from feed.views import IndicatorTypeViewSet
 from workflow.models import WorkflowTeam, ROLE_ORGANIZATION_ADMIN, \
     ROLE_PROGRAM_TEAM, ROLE_PROGRAM_ADMIN, ROLE_VIEW_ONLY
 
 
-class CustomFormListViewsTest(TestCase):
+class IndicatorTypeListViewsTest(TestCase):
     def setUp(self):
         factories.Organization(id=1)
-        factories.CustomForm.create_batch(2)
+        factories.IndicatorType.create_batch(2)
         self.factory = APIRequestFactory()
         self.tola_user = factories.TolaUser()
 
-    def test_list_customform_superuser(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_indicatortype_superuser(self):
+        request = self.factory.get('/api/indicatortype/')
         request.user = factories.User.build(is_superuser=True,
                                             is_staff=True)
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = IndicatorTypeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 2)
 
-    def test_list_customform_org_admin(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_indicatortype_org_admin(self):
+        request = self.factory.get('/api/indicatortype/')
         group_org_admin = factories.Group(name=ROLE_ORGANIZATION_ADMIN)
         self.tola_user.user.groups.add(group_org_admin)
 
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = IndicatorTypeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.IndicatorType(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
-    def test_list_customform_program_admin(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_indicatortype_program_admin(self):
+        request = self.factory.get('/api/indicatortype/')
         WorkflowTeam.objects.create(
             workflow_user=self.tola_user,
             role=factories.Group(name=ROLE_PROGRAM_ADMIN))
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = IndicatorTypeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.IndicatorType(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
-    def test_list_customform_program_team(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_indicatortype_program_team(self):
+        request = self.factory.get('/api/indicatortype/')
         WorkflowTeam.objects.create(
             workflow_user=self.tola_user,
             role=factories.Group(name=ROLE_PROGRAM_TEAM))
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = IndicatorTypeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.IndicatorType(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
-    def test_list_customform_view_only(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_indicatortype_view_only(self):
+        request = self.factory.get('/api/indicatortype/')
         WorkflowTeam.objects.create(
             workflow_user=self.tola_user,
             role=factories.Group(name=ROLE_VIEW_ONLY))
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = IndicatorTypeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.IndicatorType(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
 
-class CustomFormCreateViewTest(TestCase):
+class IndicatorTypeFilterViewTest(TestCase):
     def setUp(self):
-        self.user = factories.User(is_superuser=True, is_staff=True)
-        self.organization = factories.Organization(id=1)
-        factories.TolaUser(user=self.user, organization=self.organization)
-        factory = APIRequestFactory()
-        self.request = factory.post('/api/customform/')
-
-    def test_create_customform(self):
-        user_url = reverse('user-detail', kwargs={'pk': self.user.id},
-                           request=self.request)
-
-        data = {'name': '4W Daily Activity Report'}
-        self.request = APIRequestFactory().post('/api/customform/', data)
-        self.request.user = self.user
-        view = CustomFormViewSet.as_view({'post': 'create'})
-        response = view(self.request)
-
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.data['name'], u'4W Daily Activity Report')
-        self.assertEqual(response.data['created_by'], user_url)
-
-
-class CustomFormFilterViewsTest(TestCase):
-    def setUp(self):
-        self.factory = APIRequestFactory()
         self.tola_user = factories.TolaUser()
+        self.factory = APIRequestFactory()
 
-    def test_filter_customform_superuser(self):
+    def test_filter_indicatortype_superuser(self):
+        another_org = factories.Organization(name='Another Org')
+        indicatortype1_1 = factories.IndicatorType(
+            organization=self.tola_user.organization)
+        factories.IndicatorType(indicator_type='Another IndicatorType',
+                                organization=another_org)
+
         self.tola_user.user.is_staff = True
         self.tola_user.user.is_superuser = True
         self.tola_user.user.save()
 
-        ext_serv1 = factories.CustomForm(
-            organization=self.tola_user.organization)
-        factories.CustomForm(name='Custom Form B')
-        request = self.factory.get('/api/customform/?organization__id=%s' %
+        request = self.factory.get('/api/indicatortype/?organization__id=%s' %
                                    self.tola_user.organization.pk)
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = IndicatorTypeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
-        self.assertEqual(response.data[0]['name'], ext_serv1.name)
+        self.assertEqual(response.data[0]['indicator_type'],
+                         indicatortype1_1.indicator_type)
+
+    def test_filter_indicatortype_normaluser(self):
+        another_org = factories.Organization(name='Another Org')
+        indicatortype1_1 = factories.IndicatorType(
+            organization=self.tola_user.organization)
+        factories.IndicatorType(indicator_type='Another IndicatorType',
+                                organization=another_org)
+
+        request = self.factory.get('/api/indicatortype/?organization__id=%s' %
+                                   self.tola_user.organization.pk)
+        request.user = self.tola_user.user
+        view = IndicatorTypeViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['indicator_type'],
+                         indicatortype1_1.indicator_type)

--- a/feed/tests/test_issueregisterview.py
+++ b/feed/tests/test_issueregisterview.py
@@ -3,50 +3,96 @@ from rest_framework.test import APIRequestFactory
 
 import factories
 from feed.views import IssueRegisterViewSet
-from workflow.models import IssueRegister
 
 
-class IssueRegisterViewsTest(TestCase):
+class IssueRegisterListViewTest(TestCase):
     def setUp(self):
         self.tola_user = factories.TolaUser()
-        IssueRegister.objects.bulk_create([
-            IssueRegister(name='IssueRegister1'),
-            IssueRegister(name='IssueRegister2'),
-        ])
-
-        factory = APIRequestFactory()
-        self.request_get = factory.get('/api/issueregister/')
-        self.request_get.user = self.tola_user.user
-        self.request_post = factory.post('/api/issueregister/')
-        self.request_post.user = self.tola_user.user
+        factories.IssueRegister.create_batch(2)
+        self.factory = APIRequestFactory()
 
     def test_list_issueregister_superuser(self):
-        self.request_get.user = factories.User.build(is_superuser=True, is_staff=True)
+        self.tola_user.user.is_staff = True
+        self.tola_user.user.is_superuser = True
+        self.tola_user.user.save()
+
+        request = self.factory.get('/api/issueregister/')
+        request.user = self.tola_user.user
         view = IssueRegisterViewSet.as_view({'get': 'list'})
-        response = view(self.request_get)
+        response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 2)
 
     def test_list_issueregister_normaluser(self):
         view = IssueRegisterViewSet.as_view({'get': 'list'})
-        response = view(self.request_get)
+        request = self.factory.get('/api/issueregister/')
+        request.user = self.tola_user.user
+        response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
     def test_list_issueregister_normaluser_one_result(self):
-        IssueRegister.objects.create(name='IssueRegister0', organization=self.tola_user.organization)
+        factories.IssueRegister(
+            name='IssueRegister0', organization=self.tola_user.organization)
         view = IssueRegisterViewSet.as_view({'get': 'list'})
-        response = view(self.request_get)
+        request = self.factory.get('/api/issueregister/')
+        request.user = self.tola_user.user
+        response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
-    
+
+
+class IssueRegisterCreateViewTest(TestCase):
+    def setUp(self):
+        self.tola_user = factories.TolaUser()
+        self.factory = APIRequestFactory()
+
     def test_create_issueregister_normaluser_one_result(self):
+        self.tola_user.user.is_staff = True
+        self.tola_user.user.is_superuser = True
+        self.tola_user.user.save()
+
+        request = self.factory.post('/api/issueregister/')
+        request.user = self.tola_user.user
         view = IssueRegisterViewSet.as_view({'post': 'create'})
-        response = view(self.request_post)
+        response = view(request)
         self.assertEqual(response.status_code, 201)
 
         # check if the obj created has the user organization
+        request = self.factory.get('/api/issueregister/')
+        request.user = self.tola_user.user
         view = IssueRegisterViewSet.as_view({'get': 'list'})
-        response = view(self.request_get)
+        response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
+
+
+class IssueRegisterFilterViewTest(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.tola_user = factories.TolaUser()
+
+    def test_filter_issueregister_org_superuser(self):
+        self.tola_user.user.is_staff = True
+        self.tola_user.user.is_superuser = True
+        self.tola_user.user.save()
+
+        another_org = factories.Organization(name='Another Org')
+        wkflvl1_1 = factories.WorkflowLevel1(
+            organization=self.tola_user.organization)
+        wkflvl1_2 = factories.WorkflowLevel1(organization=another_org)
+        wkflvl2_1 = factories.WorkflowLevel2(workflowlevel1=wkflvl1_1)
+        wkflvl2_2 = factories.WorkflowLevel2(workflowlevel1=wkflvl1_2)
+        issueregister1 = factories.IssueRegister(workflowlevel2=wkflvl2_1)
+        factories.IssueRegister(name='coded_field_b', workflowlevel2=wkflvl2_2)
+
+        request = self.factory.get(
+            '/api/issueregister'
+            '/?workflowlevel2__workflowlevel1__organization__id=%s'
+            % self.tola_user.organization.pk)
+        request.user = self.tola_user.user
+        view = IssueRegisterViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], issueregister1.name)

--- a/feed/tests/test_levelview.py
+++ b/feed/tests/test_levelview.py
@@ -489,3 +489,51 @@ class LevelDeleteViewsTest(TestCase):
         response = view(request, pk=level.pk)
         self.assertEquals(response.status_code, 403)
         Level.objects.get(pk=level.pk)
+
+        
+class LevelFilterViewTest(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.tola_user = factories.TolaUser()
+
+    def test_filter_level_superuser(self):
+        self.tola_user.user.is_staff = True
+        self.tola_user.user.is_superuser = True
+        self.tola_user.user.save()
+
+        another_org = factories.Organization(name='Another Org')
+        level1 = factories.Level(
+            name='Level 1',
+            organization=self.tola_user.organization)
+        factories.Level(name='Level 2', organization=another_org)
+
+        request = self.factory.get(
+            '/api/level/?organization__id=%s' %
+            self.tola_user.organization.pk)
+        request.user = self.tola_user.user
+        view = LevelViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], level1.name)
+
+    def test_filter_level_normaluser(self):
+        country1 = factories.Country(country='Brazil', code='BR')
+        country2 = factories.Country()
+        level1 = factories.Level(
+            name='Level 1',
+            country=country1,
+            organization=self.tola_user.organization
+        )
+        factories.Level(name='Level 2', country=country2,
+                        organization=self.tola_user.organization)
+
+        request = self.factory.get(
+            '/api/level/?country__country=%s' %
+            country1.country)
+        request.user = self.tola_user.user
+        view = LevelViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], level1.name)

--- a/feed/tests/test_profiletypeview.py
+++ b/feed/tests/test_profiletypeview.py
@@ -1,135 +1,113 @@
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory
-from rest_framework.reverse import reverse
 
 import factories
-from feed.views import CustomFormViewSet
+from feed.views import ProfileTypeViewSet
 from workflow.models import WorkflowTeam, ROLE_ORGANIZATION_ADMIN, \
     ROLE_PROGRAM_TEAM, ROLE_PROGRAM_ADMIN, ROLE_VIEW_ONLY
 
 
-class CustomFormListViewsTest(TestCase):
+class ProfileTypeListViewsTest(TestCase):
     def setUp(self):
         factories.Organization(id=1)
-        factories.CustomForm.create_batch(2)
+        factories.ProfileType.create_batch(2)
         self.factory = APIRequestFactory()
         self.tola_user = factories.TolaUser()
 
-    def test_list_customform_superuser(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_profiletype_superuser(self):
+        request = self.factory.get('/api/profiletype/')
         request.user = factories.User.build(is_superuser=True,
                                             is_staff=True)
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = ProfileTypeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 2)
 
-    def test_list_customform_org_admin(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_profiletype_org_admin(self):
+        request = self.factory.get('/api/profiletype/')
         group_org_admin = factories.Group(name=ROLE_ORGANIZATION_ADMIN)
         self.tola_user.user.groups.add(group_org_admin)
 
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = ProfileTypeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.ProfileType(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
-    def test_list_customform_program_admin(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_profiletype_program_admin(self):
+        request = self.factory.get('/api/profiletype/')
         WorkflowTeam.objects.create(
             workflow_user=self.tola_user,
             role=factories.Group(name=ROLE_PROGRAM_ADMIN))
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = ProfileTypeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.ProfileType(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
-    def test_list_customform_program_team(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_profiletype_program_team(self):
+        request = self.factory.get('/api/profiletype/')
         WorkflowTeam.objects.create(
             workflow_user=self.tola_user,
             role=factories.Group(name=ROLE_PROGRAM_TEAM))
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = ProfileTypeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.ProfileType(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
-    def test_list_customform_view_only(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_profiletype_view_only(self):
+        request = self.factory.get('/api/profiletype/')
         WorkflowTeam.objects.create(
             workflow_user=self.tola_user,
             role=factories.Group(name=ROLE_VIEW_ONLY))
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = ProfileTypeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.ProfileType(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
 
-class CustomFormCreateViewTest(TestCase):
+class ProfileTypeFilterViewsTest(TestCase):
     def setUp(self):
-        self.user = factories.User(is_superuser=True, is_staff=True)
-        self.organization = factories.Organization(id=1)
-        factories.TolaUser(user=self.user, organization=self.organization)
-        factory = APIRequestFactory()
-        self.request = factory.post('/api/customform/')
-
-    def test_create_customform(self):
-        user_url = reverse('user-detail', kwargs={'pk': self.user.id},
-                           request=self.request)
-
-        data = {'name': '4W Daily Activity Report'}
-        self.request = APIRequestFactory().post('/api/customform/', data)
-        self.request.user = self.user
-        view = CustomFormViewSet.as_view({'post': 'create'})
-        response = view(self.request)
-
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.data['name'], u'4W Daily Activity Report')
-        self.assertEqual(response.data['created_by'], user_url)
-
-
-class CustomFormFilterViewsTest(TestCase):
-    def setUp(self):
+        factories.Organization(id=1)
         self.factory = APIRequestFactory()
         self.tola_user = factories.TolaUser()
 
-    def test_filter_customform_superuser(self):
+    def test_filter_profiletype_superuser(self):
         self.tola_user.user.is_staff = True
         self.tola_user.user.is_superuser = True
         self.tola_user.user.save()
 
-        ext_serv1 = factories.CustomForm(
+        p_type1 = factories.ProfileType(
             organization=self.tola_user.organization)
-        factories.CustomForm(name='Custom Form B')
-        request = self.factory.get('/api/customform/?organization__id=%s' %
+        p_type2 = factories.ProfileType(profile='Camp Site')
+        request = self.factory.get('/api/profiletype/?organization__id=%s' %
                                    self.tola_user.organization.pk)
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = ProfileTypeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
-        self.assertEqual(response.data[0]['name'], ext_serv1.name)
+        self.assertEqual(response.data[0]['profile'], p_type1.profile)
+        self.assertNotEqual(response.data[0]['profile'], p_type2.profile)

--- a/feed/tests/test_projecttypeview.py
+++ b/feed/tests/test_projecttypeview.py
@@ -1,135 +1,132 @@
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory
-from rest_framework.reverse import reverse
 
 import factories
-from feed.views import CustomFormViewSet
+from feed.views import ProjectTypeViewSet
 from workflow.models import WorkflowTeam, ROLE_ORGANIZATION_ADMIN, \
     ROLE_PROGRAM_TEAM, ROLE_PROGRAM_ADMIN, ROLE_VIEW_ONLY
 
 
-class CustomFormListViewsTest(TestCase):
+class ProjectTypeListViewsTest(TestCase):
     def setUp(self):
         factories.Organization(id=1)
-        factories.CustomForm.create_batch(2)
+        factories.ProjectType.create_batch(2)
         self.factory = APIRequestFactory()
         self.tola_user = factories.TolaUser()
 
-    def test_list_customform_superuser(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_projecttype_superuser(self):
+        request = self.factory.get('/api/projecttype/')
         request.user = factories.User.build(is_superuser=True,
                                             is_staff=True)
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = ProjectTypeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 2)
 
-    def test_list_customform_org_admin(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_projecttype_org_admin(self):
+        request = self.factory.get('/api/projecttype/')
         group_org_admin = factories.Group(name=ROLE_ORGANIZATION_ADMIN)
         self.tola_user.user.groups.add(group_org_admin)
 
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = ProjectTypeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.ProjectType(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
-    def test_list_customform_program_admin(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_projecttype_program_admin(self):
+        request = self.factory.get('/api/projecttype/')
         WorkflowTeam.objects.create(
             workflow_user=self.tola_user,
             role=factories.Group(name=ROLE_PROGRAM_ADMIN))
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = ProjectTypeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.ProjectType(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
-    def test_list_customform_program_team(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_projecttype_program_team(self):
+        request = self.factory.get('/api/projecttype/')
         WorkflowTeam.objects.create(
             workflow_user=self.tola_user,
             role=factories.Group(name=ROLE_PROGRAM_TEAM))
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = ProjectTypeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.ProjectType(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
-    def test_list_customform_view_only(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_projecttype_view_only(self):
+        request = self.factory.get('/api/projecttype/')
         WorkflowTeam.objects.create(
             workflow_user=self.tola_user,
             role=factories.Group(name=ROLE_VIEW_ONLY))
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = ProjectTypeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.ProjectType(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
 
-class CustomFormCreateViewTest(TestCase):
+class ProjectTypeFilterViewTest(TestCase):
     def setUp(self):
-        self.user = factories.User(is_superuser=True, is_staff=True)
-        self.organization = factories.Organization(id=1)
-        factories.TolaUser(user=self.user, organization=self.organization)
-        factory = APIRequestFactory()
-        self.request = factory.post('/api/customform/')
-
-    def test_create_customform(self):
-        user_url = reverse('user-detail', kwargs={'pk': self.user.id},
-                           request=self.request)
-
-        data = {'name': '4W Daily Activity Report'}
-        self.request = APIRequestFactory().post('/api/customform/', data)
-        self.request.user = self.user
-        view = CustomFormViewSet.as_view({'post': 'create'})
-        response = view(self.request)
-
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.data['name'], u'4W Daily Activity Report')
-        self.assertEqual(response.data['created_by'], user_url)
-
-
-class CustomFormFilterViewsTest(TestCase):
-    def setUp(self):
-        self.factory = APIRequestFactory()
         self.tola_user = factories.TolaUser()
+        self.factory = APIRequestFactory()
 
-    def test_filter_customform_superuser(self):
+    def test_filter_projecttype_superuser(self):
+        another_org = factories.Organization(name='Another Org')
+        projecttype1_1 = factories.ProjectType(
+            organization=self.tola_user.organization)
+        factories.ProjectType(
+            name='Another ProjectType',
+            organization=another_org)
+
         self.tola_user.user.is_staff = True
         self.tola_user.user.is_superuser = True
         self.tola_user.user.save()
 
-        ext_serv1 = factories.CustomForm(
-            organization=self.tola_user.organization)
-        factories.CustomForm(name='Custom Form B')
-        request = self.factory.get('/api/customform/?organization__id=%s' %
+        request = self.factory.get('/api/projecttype/?organization__id=%s' %
                                    self.tola_user.organization.pk)
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = ProjectTypeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
-        self.assertEqual(response.data[0]['name'], ext_serv1.name)
+        self.assertEqual(response.data[0]['name'], projecttype1_1.name)
+
+    def test_filter_projecttype_normaluser(self):
+        another_org = factories.Organization(name='Another Org')
+        projecttype1_1 = factories.ProjectType(
+            organization=self.tola_user.organization)
+        factories.ProjectType(
+            name='Another ProjectType',
+            organization=another_org)
+
+        request = self.factory.get('/api/projecttype/?organization__id=%s' %
+                                   self.tola_user.organization.pk)
+        request.user = self.tola_user.user
+        view = ProjectTypeViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], projecttype1_1.name)

--- a/feed/tests/test_sectorview.py
+++ b/feed/tests/test_sectorview.py
@@ -7,39 +7,78 @@ import factories
 from feed.views import SectorViewSet
 
 
-class SectorViewTest(TestCase):
+class SectorCreateViewTest(TestCase):
     def setUp(self):
-        self.user = factories.User(is_superuser=True, is_staff=True)
         self.organization = factories.Organization(id=1)
-        factories.TolaUser(user=self.user, organization=self.organization)
-        factory = APIRequestFactory()
-        self.request = factory.post('/api/sector/')
+        self.tola_user = factories.TolaUser(organization=self.organization)
+        self.factory = APIRequestFactory()
 
     def test_create_sector(self):
-        user_url = reverse('user-detail', kwargs={'pk': self.user.id},
-                           request=self.request)
+        request = self.factory.post('/api/sector/')
+        user_url = reverse('user-detail', kwargs={'pk': self.tola_user.user.id},
+                           request=request)
 
         data = {'sector': 'Agriculture'}
-        self.request = APIRequestFactory().post('/api/sector/', data)
-        self.request.user = self.user
+        request = self.factory.post('/api/sector/', data)
+        request.user = self.tola_user.user
         view = SectorViewSet.as_view({'post': 'create'})
-        response = view(self.request)
+        response = view(request)
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.data['sector'], u'Agriculture')
         self.assertEqual(response.data['created_by'], user_url)
 
     def test_create_sector_json(self):
-        user_url = reverse('user-detail', kwargs={'pk': self.user.id},
-                           request=self.request)
+        request = self.factory.post('/api/sector/')
+        user_url = reverse('user-detail', kwargs={'pk': self.tola_user.user.pk},
+                           request=request)
 
         data = {'sector': 'Agriculture'}
-        self.request = APIRequestFactory().post(
+        request = self.factory.post(
             '/api/sector/', json.dumps(data), content_type='application/json')
-        self.request.user = self.user
+        request.user = self.tola_user.user
         view = SectorViewSet.as_view({'post': 'create'})
-        response = view(self.request)
+        response = view(request)
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.data['sector'], u'Agriculture')
         self.assertEqual(response.data['created_by'], user_url)
+
+
+class SectorFilterViewTest(TestCase):
+    def setUp(self):
+        self.organization = factories.Organization(id=1)
+        self.tola_user = factories.TolaUser(organization=self.organization)
+        self.factory = APIRequestFactory()
+
+    def test_filter_sector_superuser(self):
+        another_org = factories.Organization(name='Another Org')
+        sector1 = factories.Sector(organization=self.tola_user.organization)
+        factories.Sector(sector='Another Sector', organization=another_org)
+
+        self.tola_user.user.is_staff = True
+        self.tola_user.user.is_superuser = True
+        self.tola_user.user.save()
+
+        request = self.factory.get('/api/sector/?organization__id=%s' %
+                                   self.tola_user.organization.pk)
+        request.user = self.tola_user.user
+        view = SectorViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['sector'], sector1.sector)
+
+    def test_filter_sector_normaluser(self):
+        another_org = factories.Organization(name='Another Org')
+        sector1 = factories.Sector(organization=self.tola_user.organization)
+        factories.Sector(sector='Another Sector', organization=another_org)
+
+        request = self.factory.get('/api/sector/?organization__id=%s' %
+                                   self.tola_user.organization.pk)
+        request.user = self.tola_user.user
+        view = SectorViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['sector'], sector1.sector)

--- a/feed/tests/test_siteprofileview.py
+++ b/feed/tests/test_siteprofileview.py
@@ -8,129 +8,167 @@ from feed.views import SiteProfileViewSet
 from workflow.models import SiteProfile
 
 
-class SiteProfileViewsTest(TestCase):
+class SiteProfileListViewTest(TestCase):
     def setUp(self):
         self.country = factories.Country()
         SiteProfile.objects.bulk_create([
             SiteProfile(name='SiteProfile1', country=self.country),
             SiteProfile(name='SiteProfile2', country=self.country),
         ])
+        factories.Indicator.create_batch(2)
 
-        factory = APIRequestFactory()
-        self.request_get = factory.get('/api/siteprofile/')
-        self.request_post = factory.post('/api/siteprofile/')
+        self.factory = APIRequestFactory()
+        self.tola_user = factories.TolaUser()
 
     def test_list_siteprofile_superuser(self):
-        self.request_get.user = factories.User.build(is_superuser=True,
-                                                     is_staff=True)
+        self.tola_user.user.is_staff = True
+        self.tola_user.user.is_superuser = True
+        self.tola_user.user.save()
+        
+        request = self.factory.get('/api/siteprofile/')
+        request.user = self.tola_user.user
         view = SiteProfileViewSet.as_view({'get': 'list'})
-        response = view(self.request_get)
+        response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 2)
 
     def test_list_siteprofile_normaluser(self):
-        tola_user = factories.TolaUser()
-
-        self.request_get.user = tola_user.user
+        request = self.factory.get('/api/siteprofile/')
+        request.user = self.tola_user.user
         view = SiteProfileViewSet.as_view({'get': 'list'})
-        response = view(self.request_get)
+        response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
     def test_list_siteprofile_normaluser_one_result(self):
-        tola_user = factories.TolaUser()
-
         SiteProfile.objects.create(name='SiteProfile0',
-                                   organization=tola_user.organization,
+                                   organization=self.tola_user.organization,
                                    country=self.country)
 
-        self.request_get.user = tola_user.user
+        request = self.factory.get('/api/siteprofile/')
+        request.user = self.tola_user.user
         view = SiteProfileViewSet.as_view({'get': 'list'})
-        response = view(self.request_get)
+        response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
-    
+
+
+class SiteProfileCreateViewTest(TestCase):
+    def setUp(self):
+        self.country = factories.Country()
+        self.factory = APIRequestFactory()
+        self.tola_user = factories.TolaUser()
+            
     def test_create_siteprofile_normaluser_one_result(self):
-        tola_user = factories.TolaUser()
-        user_url = reverse('user-detail', kwargs={'pk': tola_user.user.id},
-                           request=self.request_post)
+        request = self.factory.post('/api/siteprofile/')
+        user_url = reverse('user-detail', kwargs={'pk': self.tola_user.user.id},
+                           request=request)
         wflvl1_1 = factories.WorkflowLevel1()
         wflvl1_2 = factories.WorkflowLevel1()
         wflvl1_1_url = reverse('workflowlevel1-detail',
                                kwargs={'pk': wflvl1_1.id},
-                               request=self.request_post)
+                               request=request)
         wflvl1_2_url = reverse('workflowlevel1-detail',
                                kwargs={'pk': wflvl1_2.id},
-                               request=self.request_post)
+                               request=request)
+        country_url = reverse('country-detail',
+                              kwargs={'pk': self.country.id},
+                              request=request)
 
         data = {
             'name': 'Site Profile 1',
-            'country': 'http://testserver/api/country/%s/' % self.country.id,
+            'country': country_url,
             'workflowlevel1': [wflvl1_1_url, wflvl1_2_url]
         }
-        self.request_post = APIRequestFactory().post('/api/siteprofile/', data)
-        self.request_post.user = tola_user.user
+        request = self.factory.post('/api/siteprofile/', data)
+        request.user = self.tola_user.user
         view = SiteProfileViewSet.as_view({'post': 'create'})
-        response = view(self.request_post)
+        response = view(request)
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.data['created_by'], user_url)
 
         # check if the obj created has the user organization
-        self.request_get.user = tola_user.user
+        request = self.factory.get('/api/siteprofile/')
+        request.user = self.tola_user.user
         view = SiteProfileViewSet.as_view({'get': 'list'})
-        response = view(self.request_get)
+        response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
     def test_create_siteprofile_normaluser_one_result_json(self):
-        tola_user = factories.TolaUser()
-        user_url = reverse('user-detail', kwargs={'pk': tola_user.user.id},
-                           request=self.request_post)
+        request = self.factory.post('/api/siteprofile/')
+        user_url = reverse('user-detail', kwargs={'pk': self.tola_user.user.id},
+                           request=request)
         wflvl1_1 = factories.WorkflowLevel1()
         wflvl1_2 = factories.WorkflowLevel1()
         wflvl1_1_url = reverse('workflowlevel1-detail',
                                kwargs={'pk': wflvl1_1.id},
-                               request=self.request_post)
+                               request=request)
         wflvl1_2_url = reverse('workflowlevel1-detail',
                                kwargs={'pk': wflvl1_2.id},
-                               request=self.request_post)
+                               request=request)
+        country_url = reverse('country-detail',
+                              kwargs={'pk': self.country.id},
+                              request=request)
 
         data = {
             'name': 'Site Profile 1',
-            'country': 'http://testserver/api/country/%s/' % self.country.id,
+            'country': country_url,
             'workflowlevel1': [wflvl1_1_url, wflvl1_2_url]
         }
-        self.request_post = APIRequestFactory().post(
-            '/api/siteprofile/', json.dumps(data),
-            content_type='application/json')
-        self.request_post.user = tola_user.user
+        request = self.factory.post('/api/siteprofile/', json.dumps(data),
+                                    content_type='application/json')
+        request.user = self.tola_user.user
         view = SiteProfileViewSet.as_view({'post': 'create'})
-        response = view(self.request_post)
+        response = view(request)
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.data['created_by'], user_url)
 
         # check if the obj created has the user organization
-        self.request_get.user = tola_user.user
+        request = self.factory.get('/api/siteprofile/')
+        request.user = self.tola_user.user
         view = SiteProfileViewSet.as_view({'get': 'list'})
-        response = view(self.request_get)
+        response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
-    def test_filter_siteprofile_normaluser_one_result(self):
-        tola_user = factories.TolaUser()
 
-        site = SiteProfile.objects.create(name='SiteProfile0',
-                                          organization=tola_user.organization,
-                                          country=self.country)
-        wkf1 = factories.WorkflowLevel1()
-        wkf2 = factories.WorkflowLevel2.create(workflowlevel1=wkf1)
-        wkf2.site.add(site)
+class SiteProfileFilterViewTest(TestCase):
+    def setUp(self):
+        self.country = factories.Country(country='Brazil', code='BR')
+        self.factory = APIRequestFactory()
+        self.tola_user = factories.TolaUser()
 
-        path = \
-            '/api/siteprofile/?workflowlevel2__workflowlevel1=%s' % wkf1.id
-        request_get = APIRequestFactory().get(path)
-        request_get.user = tola_user.user
+    def test_filter_siteprofile_superuser(self):
+        self.tola_user.user.is_staff = True
+        self.tola_user.user.is_superuser = True
+        self.tola_user.user.save()
+
+        site1 = factories.SiteProfile(name='SiteProfile1',
+                                        country=self.country)
+        factories.SiteProfile(name='SiteProfile2', country=factories.Country())
+
+        request = self.factory.get('/api/siteprofile/?country__country=%s' %
+                                   self.country.country)
+        request.user = self.tola_user.user
         view = SiteProfileViewSet.as_view({'get': 'list'})
-        response = view(request_get)
+        response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], site1.name)
+
+    def test_filter_siteprofile_normaluser(self):
+        site1 = factories.SiteProfile(
+            name='SiteProfile1', country=self.country,
+            organization=self.tola_user.organization)
+        factories.SiteProfile(name='SiteProfile2', country=factories.Country(),
+                              organization=self.tola_user.organization)
+
+        request = self.factory.get('/api/siteprofile/?country__country=%s' %
+                                   self.country.country)
+        request.user = self.tola_user.user
+        view = SiteProfileViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], site1.name)

--- a/feed/tests/test_stakeholdertypeview.py
+++ b/feed/tests/test_stakeholdertypeview.py
@@ -1,135 +1,112 @@
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory
-from rest_framework.reverse import reverse
 
 import factories
-from feed.views import CustomFormViewSet
+from feed.views import StakeholderTypeViewSet
 from workflow.models import WorkflowTeam, ROLE_ORGANIZATION_ADMIN, \
     ROLE_PROGRAM_TEAM, ROLE_PROGRAM_ADMIN, ROLE_VIEW_ONLY
 
 
-class CustomFormListViewsTest(TestCase):
+class StakeholderTypeListViewsTest(TestCase):
     def setUp(self):
         factories.Organization(id=1)
-        factories.CustomForm.create_batch(2)
+        factories.StakeholderType.create_batch(2)
         self.factory = APIRequestFactory()
         self.tola_user = factories.TolaUser()
 
-    def test_list_customform_superuser(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_stakeholdertype_superuser(self):
+        request = self.factory.get('/api/stakeholdertype/')
         request.user = factories.User.build(is_superuser=True,
                                             is_staff=True)
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = StakeholderTypeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 2)
 
-    def test_list_customform_org_admin(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_stakeholdertype_org_admin(self):
+        request = self.factory.get('/api/stakeholdertype/')
         group_org_admin = factories.Group(name=ROLE_ORGANIZATION_ADMIN)
         self.tola_user.user.groups.add(group_org_admin)
 
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = StakeholderTypeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.StakeholderType(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
-    def test_list_customform_program_admin(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_stakeholdertype_program_admin(self):
+        request = self.factory.get('/api/stakeholdertype/')
         WorkflowTeam.objects.create(
             workflow_user=self.tola_user,
             role=factories.Group(name=ROLE_PROGRAM_ADMIN))
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = StakeholderTypeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.StakeholderType(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
-    def test_list_customform_program_team(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_stakeholdertype_program_team(self):
+        request = self.factory.get('/api/stakeholdertype/')
         WorkflowTeam.objects.create(
             workflow_user=self.tola_user,
             role=factories.Group(name=ROLE_PROGRAM_TEAM))
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = StakeholderTypeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.StakeholderType(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
-    def test_list_customform_view_only(self):
-        request = self.factory.get('/api/customform/')
+    def test_list_stakeholdertype_view_only(self):
+        request = self.factory.get('/api/stakeholdertype/')
         WorkflowTeam.objects.create(
             workflow_user=self.tola_user,
             role=factories.Group(name=ROLE_VIEW_ONLY))
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = StakeholderTypeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
-        factories.CustomForm(organization=self.tola_user.organization)
+        factories.StakeholderType(organization=self.tola_user.organization)
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
 
-class CustomFormCreateViewTest(TestCase):
+class StakeholderTypeFilterViewTest(TestCase):
     def setUp(self):
-        self.user = factories.User(is_superuser=True, is_staff=True)
-        self.organization = factories.Organization(id=1)
-        factories.TolaUser(user=self.user, organization=self.organization)
-        factory = APIRequestFactory()
-        self.request = factory.post('/api/customform/')
-
-    def test_create_customform(self):
-        user_url = reverse('user-detail', kwargs={'pk': self.user.id},
-                           request=self.request)
-
-        data = {'name': '4W Daily Activity Report'}
-        self.request = APIRequestFactory().post('/api/customform/', data)
-        self.request.user = self.user
-        view = CustomFormViewSet.as_view({'post': 'create'})
-        response = view(self.request)
-
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(response.data['name'], u'4W Daily Activity Report')
-        self.assertEqual(response.data['created_by'], user_url)
-
-
-class CustomFormFilterViewsTest(TestCase):
-    def setUp(self):
+        factories.Organization(id=1)
         self.factory = APIRequestFactory()
         self.tola_user = factories.TolaUser()
 
-    def test_filter_customform_superuser(self):
+    def test_filter_stakeholdertype_superuser(self):
         self.tola_user.user.is_staff = True
         self.tola_user.user.is_superuser = True
         self.tola_user.user.save()
 
-        ext_serv1 = factories.CustomForm(
+        stkh_type1 = factories.StakeholderType(
             organization=self.tola_user.organization)
-        factories.CustomForm(name='Custom Form B')
-        request = self.factory.get('/api/customform/?organization__id=%s' %
+        factories.StakeholderType(name='Business')
+        request = self.factory.get('/api/stakeholdertype/?organization__id=%s' %
                                    self.tola_user.organization.pk)
         request.user = self.tola_user.user
-        view = CustomFormViewSet.as_view({'get': 'list'})
+        view = StakeholderTypeViewSet.as_view({'get': 'list'})
         response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
-        self.assertEqual(response.data[0]['name'], ext_serv1.name)
+        self.assertEqual(response.data[0]['name'], stkh_type1.name)

--- a/feed/tests/test_stakeholderview.py
+++ b/feed/tests/test_stakeholderview.py
@@ -10,31 +10,29 @@ from workflow.models import Stakeholder, Organization, WorkflowLevel1, \
     WorkflowTeam
 
 
-class StakeholderViewsTest(TestCase):
+class StakeholderListViewTest(TestCase):
     def setUp(self):
         self.tola_user = factories.TolaUser()
-        Stakeholder.objects.create(name='Stakeholder_0',
-                                   organization=self.tola_user.organization)
-
-        factory = APIRequestFactory()
-        self.request_get = factory.get('/api/stakeholder/')
-        self.request_post = factory.post('/api/stakeholder/')
+        factories.Stakeholder.create_batch(2)
+        self.factory = APIRequestFactory()
 
     def test_list_stakeholder_superuser(self):
         self.tola_user.user.is_superuser = True
         self.tola_user.user.is_staff = True
         self.tola_user.user.save()
 
-        self.request_get.user = self.tola_user.user
+        request = self.factory.get('/api/stakeholder/')
+        request.user = self.tola_user.user
         view = StakeholderViewSet.as_view({'get': 'list'})
-        response = view(self.request_get)
+        response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
     def test_list_stakeholder_normaluser(self):
-        self.request_get.user = self.tola_user.user
+        request = self.factory.get('/api/stakeholder/')
+        request.user = self.tola_user.user
         view = StakeholderViewSet.as_view({'get': 'list'})
-        response = view(self.request_get)
+        response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
@@ -46,58 +44,105 @@ class StakeholderViewsTest(TestCase):
             name='Stakeholder_0', organization=self.tola_user.organization)
         stk.workflowlevel1.add(wflvl1)
 
-        self.request_get.user = self.tola_user.user
+        request = self.factory.get('/api/stakeholder/')
+        request.user = self.tola_user.user
         view = StakeholderViewSet.as_view({'get': 'list'})
-        response = view(self.request_get)
+        response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
+
+class StakeholderCreateViewTest(TestCase):
+    def setUp(self):
+        self.tola_user = factories.TolaUser()
+        self.factory = APIRequestFactory()
+        Stakeholder.objects.create(name='Stakeholder_0',
+                                   organization=self.tola_user.organization)
+
     def test_create_stakeholder_normaluser_one_result(self):
+        request = self.factory.post('/api/stakeholder/')
         wflvl1 = WorkflowLevel1.objects.create(name='WorkflowLevel1')
         WorkflowTeam.objects.create(workflow_user=self.tola_user,
                                     workflowlevel1=wflvl1)
         user_url = reverse('user-detail', kwargs={'pk': self.tola_user.user.id},
-                           request=self.request_post)
+                           request=request)
 
         # create stakeholder via POST request
         data = {'workflowlevel1': [
             'http://testserver/api/workflowlevel1/%s/' % wflvl1.id]}
-        self.request_post = APIRequestFactory().post('/api/stakeholder/', data)
-        self.request_post.user = self.tola_user.user
+        request = self.factory.post('/api/stakeholder/', data)
+        request.user = self.tola_user.user
         view = StakeholderViewSet.as_view({'post': 'create'})
-        response = view(self.request_post)
+        response = view(request)
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.data['created_by'], user_url)
 
         # check if the obj created has the user organization
-        self.request_get.user = self.tola_user.user
+        request = self.factory.get('/api/stakeholder/')
+        request.user = self.tola_user.user
         view = StakeholderViewSet.as_view({'get': 'list'})
-        response = view(self.request_get)
+        response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
 
     def test_create_stakeholder_normaluser_one_result_json(self):
+        request = self.factory.post('/api/stakeholder/')
         wflvl1 = WorkflowLevel1.objects.create(name='WorkflowLevel1')
         WorkflowTeam.objects.create(workflow_user=self.tola_user,
                                     workflowlevel1=wflvl1)
         user_url = reverse('user-detail', kwargs={'pk': self.tola_user.user.id},
-                           request=self.request_post)
+                           request=request)
 
         # create stakeholder via POST request
         data = {'workflowlevel1': [
             'http://testserver/api/workflowlevel1/%s/' % wflvl1.id]}
-        self.request_post = APIRequestFactory().post(
+        request = self.factory.post(
             '/api/stakeholder/', json.dumps(data),
             content_type='application/json')
-        self.request_post.user = self.tola_user.user
+        request.user = self.tola_user.user
         view = StakeholderViewSet.as_view({'post': 'create'})
-        response = view(self.request_post)
+        response = view(request)
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.data['created_by'], user_url)
 
         # check if the obj created has the user organization
-        self.request_get.user = self.tola_user.user
+        request = self.factory.get('/api/stakeholder/')
+        request.user = self.tola_user.user
         view = StakeholderViewSet.as_view({'get': 'list'})
-        response = view(self.request_get)
+        response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
+
+
+class StakeholderFilterViewTest(TestCase):
+    def setUp(self):
+        self.tola_user = factories.TolaUser()
+        factories.Stakeholder.create_batch(2)
+        self.factory = APIRequestFactory()
+
+    def test_filter_stakeholder(self):
+        wflvl1_1 = factories.WorkflowLevel1(name='WorkflowLevel1')
+        wflvl1_2 = factories.WorkflowLevel1()
+        factories.WorkflowTeam(workflow_user=self.tola_user,
+                               workflowlevel1=wflvl1_1)
+        factories.WorkflowTeam(workflow_user=self.tola_user,
+                               workflowlevel1=wflvl1_2)
+        stk1 = factories.Stakeholder(
+            name='Stakeholder_1',
+            organization=self.tola_user.organization,
+            workflowlevel1=[wflvl1_1]
+        )
+        factories.Stakeholder(
+            name='Stakeholder_2',
+            organization=self.tola_user.organization,
+            workflowlevel1=[wflvl1_2]
+        )
+
+        request = self.factory.get(
+            '/api/stakeholder/?workflowlevel1__name=%s' % wflvl1_1.name)
+        request.user = self.tola_user.user
+        view = StakeholderViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], stk1.name)

--- a/feed/tests/test_strategicobjectiveview.py
+++ b/feed/tests/test_strategicobjectiveview.py
@@ -3,58 +3,115 @@ from rest_framework.test import APIRequestFactory
 
 import factories
 from feed.views import StrategicObjectiveViewSet
-from indicators.models import StrategicObjective
 
 
-class StrategicObjectiveViewsTest(TestCase):
+class StrategicObjectiveListViewTest(TestCase):
     def setUp(self):
-        StrategicObjective.objects.bulk_create([
-            StrategicObjective(name='StrategicObjective1'),
-            StrategicObjective(name='StrategicObjective2'),
-        ])
-
-        factory = APIRequestFactory()
-        self.request_get = factory.get('/api/strategicobjective/')
-        self.request_post = factory.post('/api/strategicobjective/')
+        factories.StrategicObjective.create_batch(2)
+        self.tola_user = factories.TolaUser()
+        self.factory = APIRequestFactory()
 
     def test_list_strategicobjective_superuser(self):
-        self.request_get.user = factories.User.build(is_superuser=True, is_staff=True)
+        self.tola_user.user.is_staff = True
+        self.tola_user.user.is_superuser = True
+        self.tola_user.user.save()
+
+        request = self.factory.get('/api/strategicobjective/')
+        request.user = self.tola_user.user
         view = StrategicObjectiveViewSet.as_view({'get': 'list'})
-        response = view(self.request_get)
+        response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 2)
 
     def test_list_strategicobjective_normaluser(self):
-        tola_user = factories.TolaUser()
-
-        self.request_get.user = tola_user.user
+        request = self.factory.get('/api/strategicobjective/')
+        request.user = self.tola_user.user
         view = StrategicObjectiveViewSet.as_view({'get': 'list'})
-        response = view(self.request_get)
+        response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
 
     def test_list_strategicobjective_normaluser_one_result(self):
-        tola_user = factories.TolaUser()
 
-        StrategicObjective.objects.create(name='StrategicObjective0', organization=tola_user.organization)
-
-        self.request_get.user = tola_user.user
+        factories.StrategicObjective(
+            name='StrategicObjective0',
+            organization=self.tola_user.organization)
+        request = self.factory.get('/api/strategicobjective/')
+        request.user = self.tola_user.user
         view = StrategicObjectiveViewSet.as_view({'get': 'list'})
-        response = view(self.request_get)
+        response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
-    
-    def test_create_strategicobjective_normaluser_one_result(self):
-        tola_user = factories.TolaUser()
 
-        self.request_post.user = tola_user.user
+
+class StrategicObjectiveCreateViewTest(TestCase):
+    def setUp(self):
+        self.tola_user = factories.TolaUser()
+        self.factory = APIRequestFactory()
+            
+    def test_create_strategicobjective_normaluser_one_result(self):
+        request = self.factory.post('/api/strategicobjective/')
+        request.user = self.tola_user.user
         view = StrategicObjectiveViewSet.as_view({'post': 'create'})
-        response = view(self.request_post)
+        response = view(request)
         self.assertEqual(response.status_code, 201)
 
         # check if the obj created has the user organization
-        self.request_get.user = tola_user.user
+        request = self.factory.get('/api/strategicobjective/')
+        request.user = self.tola_user.user
         view = StrategicObjectiveViewSet.as_view({'get': 'list'})
-        response = view(self.request_get)
+        response = view(request)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
+
+
+class StrategicObjectiveFilterViewTest(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.tola_user = factories.TolaUser()
+
+    def test_filter_strategicobjective_superuser(self):
+        self.tola_user.user.is_staff = True
+        self.tola_user.user.is_superuser = True
+        self.tola_user.user.save()
+
+        another_org = factories.Organization(name='Another Org')
+        s_obj1 = factories.StrategicObjective(
+            name='StrategicObjective1',
+            organization=self.tola_user.organization)
+        factories.StrategicObjective(name='StrategicObjective2',
+                                     organization=another_org)
+
+        request = self.factory.get(
+            '/api/strategicobjective/?organization__id=%s' %
+            self.tola_user.organization.pk)
+        request.user = self.tola_user.user
+        view = StrategicObjectiveViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], s_obj1.name)
+
+    def test_filter_strategicobjective_normaluser(self):
+        country1 = factories.Country(country='Brazil', code='BR')
+        country2 = factories.Country()
+        s_obj1 = factories.StrategicObjective(
+            name='StrategicObjective1',
+            country=country1,
+            organization=self.tola_user.organization
+        )
+        factories.StrategicObjective(
+            name='StrategicObjective2',
+            country=country2,
+            organization=self.tola_user.organization
+        )
+
+        request = self.factory.get(
+            '/api/strategicobjective/?country__country=%s' %
+            country1.country)
+        request.user = self.tola_user.user
+        view = StrategicObjectiveViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], s_obj1.name)

--- a/feed/tests/test_workflowlevel1view.py
+++ b/feed/tests/test_workflowlevel1view.py
@@ -1,4 +1,3 @@
-from django.contrib.auth.models import Group
 from django.test import TestCase
 from rest_framework.reverse import reverse
 from rest_framework.test import APIRequestFactory
@@ -73,6 +72,30 @@ class WorkflowLevel1ListViewsTest(TestCase):
         self.assertEqual(response.data[0]['budget'],
                          wflvl2.total_estimated_budget)
         self.assertEqual(response.data[0]['actuals'], wflvl2.actual_cost)
+
+    def test_list_filter_workflowlevel1_program_admin(self):
+        wflvl1 = factories.WorkflowLevel1(
+            organization=self.tola_user.organization)
+        wflvl1_2 = factories.WorkflowLevel1(
+            name='Population Health Initiative',
+            organization=self.tola_user.organization)
+        group_program_admin = factories.Group(name=ROLE_PROGRAM_ADMIN)
+        WorkflowTeam.objects.create(
+            workflow_user=self.tola_user, workflowlevel1=wflvl1,
+            role=group_program_admin)
+        WorkflowTeam.objects.create(
+            workflow_user=self.tola_user, workflowlevel1=wflvl1_2,
+            role=group_program_admin)
+
+        request = self.factory.get('/api/workflowlevel1/?name=%s' %
+                                   wflvl1.name)
+        request.user = self.tola_user.user
+        view = WorkflowLevel1ViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], wflvl1.name)
+        self.assertNotEqual(response.data[0]['name'], wflvl1_2.name)
 
     def test_list_workflowlevel1_program_team(self):
         wflvl1 = factories.WorkflowLevel1(
@@ -518,3 +541,44 @@ class WorkflowLevel1DeleteViewsTest(TestCase):
             WorkflowLevel1.DoesNotExist,
             WorkflowLevel1.objects.get, pk=response.data['id'])
         WorkflowLevel1.objects.get(pk=first_program_id)
+
+
+class WorkflowLevel1FilterViewsTest(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.tola_user = factories.TolaUser()
+        factories.Group()
+
+    def test_filter_workflowlevel1_superuser(self):
+        wflvl1 = factories.WorkflowLevel1()
+        factories.WorkflowLevel1(name='Population Health Initiative')
+
+        self.tola_user.user.is_staff = True
+        self.tola_user.user.is_superuser = True
+        self.tola_user.user.save()
+
+        request = self.factory.get('/api/workflowlevel1/?name=%s' %
+                                   wflvl1.name)
+        request.user = self.tola_user.user
+        view = WorkflowLevel1ViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], wflvl1.name)
+
+    def test_filter_workflowlevel1_org_admin(self):
+        wflvl1 = factories.WorkflowLevel1(
+            organization=self.tola_user.organization)
+        factories.WorkflowLevel1(name='Population Health Initiative',
+                                 organization=self.tola_user.organization)
+        group_org_admin = factories.Group(name=ROLE_ORGANIZATION_ADMIN)
+        self.tola_user.user.groups.add(group_org_admin)
+
+        request = self.factory.get('/api/workflowlevel1/?name=%s' %
+                                   wflvl1.name)
+        request.user = self.tola_user.user
+        view = WorkflowLevel1ViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], wflvl1.name)

--- a/feed/tests/test_workflowlevel2view.py
+++ b/feed/tests/test_workflowlevel2view.py
@@ -560,3 +560,108 @@ class WorkflowLevel2DeleteViewsTest(TestCase):
         response = view(request, pk=workflowLlevel2.pk)
         self.assertEquals(response.status_code, 403)
         WorkflowLevel2.objects.get(pk=workflowLlevel2.pk)
+
+
+class WorkflowLevel2FilterViewsTest(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.tola_user = factories.TolaUser()
+
+    def test_filter_workflowLevel2_wkflvl1_country_superuser(self):
+        self.tola_user.user.is_staff = True
+        self.tola_user.user.is_superuser = True
+        self.tola_user.user.save()
+
+        country1 = factories.Country(country='Brazil', code='BR')
+        country2 = factories.Country(country='Germany', code='DE')
+        wkflvl1_1 = factories.WorkflowLevel1(country=[country1])
+        wkflvl1_2 = factories.WorkflowLevel1(country=[country2])
+        wkflvl2 = factories.WorkflowLevel2(workflowlevel1=wkflvl1_1)
+        factories.WorkflowLevel2(
+            name='Develop brief survey', workflowlevel1=wkflvl1_2)
+
+        request = self.factory.get(
+            '/api/workflowlevel2/?workflowlevel1__country__country=%s'
+            % country1.country)
+        request.user = self.tola_user.user
+        view = WorkflowLevel2ViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], wkflvl2.name)
+
+    def test_filter_workflowLevel2_wkflvl1_name_org_admin(self):
+        group_org_admin = factories.Group(name=ROLE_ORGANIZATION_ADMIN)
+        self.tola_user.user.groups.add(group_org_admin)
+
+        wkflvl1_1 = factories.WorkflowLevel1()
+        wkflvl1_2 = factories.WorkflowLevel1(name='Construction Project')
+        WorkflowTeam.objects.create(
+            workflow_user=self.tola_user,
+            workflowlevel1=wkflvl1_1)
+        WorkflowTeam.objects.create(
+            workflow_user=self.tola_user,
+            workflowlevel1=wkflvl1_2)
+        wkflvl2 = factories.WorkflowLevel2(workflowlevel1=wkflvl1_1)
+        factories.WorkflowLevel2(
+            name='Develop brief survey', workflowlevel1=wkflvl1_2)
+
+        request = self.factory.get(
+            '/api/workflowlevel2/?workflowlevel1__name=%s'
+            % wkflvl1_1.name)
+        request.user = self.tola_user.user
+        view = WorkflowLevel2ViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], wkflvl2.name)
+
+    def test_filter_workflowLevel2_wkflvl1_id_org_admin(self):
+        group_org_admin = factories.Group(name=ROLE_ORGANIZATION_ADMIN)
+        self.tola_user.user.groups.add(group_org_admin)
+
+        wkflvl1_1 = factories.WorkflowLevel1()
+        wkflvl1_2 = factories.WorkflowLevel1()
+        WorkflowTeam.objects.create(
+            workflow_user=self.tola_user,
+            workflowlevel1=wkflvl1_1)
+        WorkflowTeam.objects.create(
+            workflow_user=self.tola_user,
+            workflowlevel1=wkflvl1_2)
+        wkflvl2 = factories.WorkflowLevel2(workflowlevel1=wkflvl1_1)
+        factories.WorkflowLevel2(
+            name='Develop brief survey', workflowlevel1=wkflvl1_2)
+
+        request = self.factory.get(
+            '/api/workflowlevel2/?workflowlevel1__id=%s'
+            % wkflvl1_1.pk)
+        request.user = self.tola_user.user
+        view = WorkflowLevel2ViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], wkflvl2.name)
+
+    def test_filter_workflowLevel2_level2_uuid_org_admin(self):
+        group_org_admin = factories.Group(name=ROLE_ORGANIZATION_ADMIN)
+        self.tola_user.user.groups.add(group_org_admin)
+
+        wkflvl1 = factories.WorkflowLevel1()
+        WorkflowTeam.objects.create(
+            workflow_user=self.tola_user,
+            workflowlevel1=wkflvl1)
+        wkflvl2 = factories.WorkflowLevel2(
+            level2_uuid=111, workflowlevel1=wkflvl1)
+        factories.WorkflowLevel2(
+            name='Develop brief survey', level2_uuid=222,
+            workflowlevel1=wkflvl1)
+
+        request = self.factory.get(
+            '/api/workflowlevel2/?level2_uuid=%s'
+            % wkflvl2.level2_uuid)
+        request.user = self.tola_user.user
+        view = WorkflowLevel2ViewSet.as_view({'get': 'list'})
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['name'], wkflvl2.name)


### PR DESCRIPTION
## Purpose
We have overwritten the list method but we don't use the `filter_queryset` method in it, so we had to update the queryset of all endpoints.

### Consideration
- Some unit tests were updated to cover more cases and have a standard.
- Some `filter_fields` were removed because they don't exist in the models anymore.

Related issue: #802 