### PR TITLE
Fix Given Name of new users is filled automatically

### DIFF
--- a/factories/workflow_models.py
+++ b/factories/workflow_models.py
@@ -22,6 +22,7 @@ from workflow.models import (
     SiteProfile as SiteProfileM,
     Stakeholder as StakeholderM,
     StakeholderType as StakeholderTypeM,
+    TolaSites as TolaSitesM,
     TolaUser as TolaUserM,
     WorkflowTeam as WorkflowTeamM,
     WorkflowLevel1 as WorkflowLevel1M,
@@ -272,3 +273,10 @@ class Milestone(DjangoModelFactory):
         model = MilestoneM
 
     name = 'Design Stage'
+
+
+class TolaSites(DjangoModelFactory):
+    class Meta:
+        model = TolaSitesM
+
+    name = 'TolaData'

--- a/tola/tests/test_utils.py
+++ b/tola/tests/test_utils.py
@@ -2,7 +2,6 @@
 import factories
 
 from django.test import TestCase
-from django.http import HttpResponse
 from workflow.models import TolaUser
 from tola import util
 

--- a/tola/tests/test_views.py
+++ b/tola/tests/test_views.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+import factories
+
+from django.contrib.sites.models import Site
+from django.contrib.auth.models import User
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.test import RequestFactory, TestCase
+
+from tola import views
+from workflow.models import TolaUser, ROLE_VIEW_ONLY
+
+# TODO Extend View tests
+
+
+class ViewsTest(TestCase):
+    """
+    Test cases for Views
+    """
+    def setUp(self):
+        site = Site.objects.create(name='TolaSite')
+        factories.TolaSites(site=site)
+        factories.Group(name=ROLE_VIEW_ONLY)
+
+        self.org = factories.Organization()
+        self.factory = RequestFactory()
+
+    def test_register_full_name(self):
+        data = {
+            'first_name': 'John',
+            'last_name': 'Lennon',
+            'email': 'johnlennon@test.com',
+            'username': 'johnlennon',
+            'password1': 'thebeatles',
+            'password2': 'thebeatles',
+            'title': '',
+            'privacy_disclaimer_accepted': 'on',
+            'org': self.org.name
+        }
+
+        request = self.factory.post('/accounts/register/', data)
+        setattr(request, 'session', 'session')
+        messages = FallbackStorage(request)
+        setattr(request, '_messages', messages)
+        response = views.register(request)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, '/accounts/login/')
+
+        tolauser = TolaUser.objects.filter(name='John Lennon')
+        user = User.objects.filter(username='johnlennon')
+        self.assertEqual(len(tolauser), 1)
+        self.assertEqual(len(user), 1)
+
+    def test_register_first_name(self):
+        data = {
+            'first_name': 'John',
+            'email': 'johnlennon@test.com',
+            'username': 'johnlennon',
+            'password1': 'thebeatles',
+            'password2': 'thebeatles',
+            'title': '',
+            'privacy_disclaimer_accepted': 'on',
+            'org': self.org.name
+        }
+
+        request = self.factory.post('/accounts/register/', data)
+        setattr(request, 'session', 'session')
+        messages = FallbackStorage(request)
+        setattr(request, '_messages', messages)
+        response = views.register(request)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, '/accounts/login/')
+
+        tolauser = TolaUser.objects.filter(name='John')
+        user = User.objects.filter(username='johnlennon')
+        self.assertEqual(len(tolauser), 1)
+        self.assertEqual(len(user), 1)

--- a/tola/views.py
+++ b/tola/views.py
@@ -46,7 +46,6 @@ def register(request):
 
         # Get the Org and check to make sure it's real
         org = request.POST.get('org')
-        print org
         try:
             check_org = Organization.objects.get(name=org)
         except Organization.DoesNotExist:
@@ -72,6 +71,7 @@ def register(request):
             user.groups.add(Group.objects.get(name=ROLE_VIEW_ONLY))
 
             tolauser = tola_form.save(commit=False)
+            tolauser.name = ' '.join([user.first_name, user.last_name]).strip()
             tolauser.user = user
             tolauser.organization = check_org
             tolauser.save()


### PR DESCRIPTION
## Purpose
Name of users from the registration form wasn't added to Tola User, it should be filled automatically.

Related issue: TolaDataV2/[#456](https://github.com/toladata/TolaDataV2/issues/456)