### PR TITLE
Fix WFL1 isn't associated with an organization

### DIFF
--- a/feed/tests/test_workflowlevel1view.py
+++ b/feed/tests/test_workflowlevel1view.py
@@ -191,6 +191,9 @@ class WorkflowLevel1CreateViewsTest(TestCase):
         A ProgramAdmin member of any other program can create a new program
         in the same organization.
         """
+        organization_url = reverse(
+            'organization-detail',
+            kwargs={'pk': self.tola_user.organization.pk})
         WorkflowTeam.objects.create(
             workflow_user=self.tola_user,
             workflowlevel1=factories.WorkflowLevel1(
@@ -204,6 +207,7 @@ class WorkflowLevel1CreateViewsTest(TestCase):
         response = view(request)
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.data['name'], u'Save the Children')
+        self.assertIn(organization_url, response.data['organization'])
 
         WorkflowTeam.objects.get(
             workflowlevel1__id=response.data['id'],

--- a/feed/views.py
+++ b/feed/views.py
@@ -103,9 +103,6 @@ class WorkflowLevel1ViewSet(viewsets.ModelViewSet):
         group_program_admin = Group.objects.get(name=ROLE_PROGRAM_ADMIN)
         wflvl1 = WorkflowLevel1.objects.get(
             level1_uuid=serializer.data['level1_uuid'])
-        wflvl1.organization = request.user.tola_user.organization
-        wflvl1.user_access.add(request.user.tola_user)
-        wflvl1.save()
         WorkflowTeam.objects.create(
             workflow_user=request.user.tola_user, workflowlevel1=wflvl1,
             role=group_program_admin)
@@ -113,6 +110,13 @@ class WorkflowLevel1ViewSet(viewsets.ModelViewSet):
         headers = self.get_success_headers(serializer.data)
         return Response(serializer.data, status=status.HTTP_201_CREATED,
                         headers=headers)
+
+    def perform_create(self, serializer):
+        organization_id = TolaUser.objects. \
+            values_list('organization_id', flat=True). \
+            get(user=self.request.user)
+        obj = serializer.save(organization_id=organization_id)
+        obj.user_access.add(self.request.user.tola_user)
 
     def destroy(self, request, pk):
         workflowlevel1 = self.get_object()


### PR DESCRIPTION
## Purpose
WFL1 has to be associated with the user's organization.

Related issue: TolaDataV2/[#554](https://github.com/toladata/TolaDataV2/issues/554)