### PR TITLE
Fix duplicated stakeholder in the stakeholder list endpoint

### DIFF
--- a/feed/tests/test_stakeholderview.py
+++ b/feed/tests/test_stakeholderview.py
@@ -37,12 +37,15 @@ class StakeholderListViewTest(TestCase):
         self.assertEqual(len(response.data), 0)
 
     def test_list_stakeholder_normaluser_one_result(self):
-        wflvl1 = WorkflowLevel1.objects.create(name='WorkflowLevel1')
+        wflvl1_1 = WorkflowLevel1.objects.create(name='WorkflowLevel1_1')
+        wflvl1_2 = WorkflowLevel1.objects.create(name='WorkflowLevel1_2')
         WorkflowTeam.objects.create(workflow_user=self.tola_user,
-                                    workflowlevel1=wflvl1)
+                                    workflowlevel1=wflvl1_1)
+        WorkflowTeam.objects.create(workflow_user=self.tola_user,
+                                    workflowlevel1=wflvl1_2)
         stk = Stakeholder.objects.create(
             name='Stakeholder_0', organization=self.tola_user.organization)
-        stk.workflowlevel1.add(wflvl1)
+        stk.workflowlevel1.add(wflvl1_1, wflvl1_2)
 
         request = self.factory.get('/api/stakeholder/')
         request.user = self.tola_user.user

--- a/feed/views.py
+++ b/feed/views.py
@@ -464,7 +464,7 @@ class StakeholderViewSet(viewsets.ModelViewSet):
         # Use this queryset or the django-filters lib will not work
         queryset = self.filter_queryset(self.get_queryset())
         wflvl1_ids = get_programs_user(request.user)
-        queryset = queryset.filter(workflowlevel1__in=wflvl1_ids)
+        queryset = queryset.filter(workflowlevel1__in=wflvl1_ids).distinct()
 
         nested = request.GET.get('nested_models')
         if nested is not None and (nested.lower() == 'true' or nested == '1'):


### PR DESCRIPTION
## Purpose
When a user fetches data from the endpoint list of stakeholder, it should get a list of no-duplicated stakeholders. 

Related issue: #803 