### PR TITLE
Make HTTPS settings configurable

### DIFF
--- a/tola/settings/base.py
+++ b/tola/settings/base.py
@@ -362,6 +362,3 @@ CORS_ORIGIN_WHITELIST = (
 
 GOOGLE_ANALYTICS_PROPERTY_ID = None  # replaced in private settings file
 GOOGLE_ANALYTICS_DOMAIN = 'example.org'  # replaced in private settings file
-
-SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
-

--- a/tola/settings/local.py
+++ b/tola/settings/local.py
@@ -30,6 +30,9 @@ if os.getenv('TOLA_HOSTNAME') is not None:
 
 USE_X_FORWARDED_HOST = True if os.getenv('TOLA_USE_X_FORWARDED_HOST') == 'True' else False
 
+if os.getenv('TOLA_USE_HTTPS') == 'True':
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 ########## MANAGER CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#admins
 ADMINS = (


### PR DESCRIPTION
Purpose
========

We need this setting in order to have https URLs in Django Rest Framework API endpoints results.