### PR TITLE
Add Registration in Track functionality

### DIFF
--- a/templates2/index.html
+++ b/templates2/index.html
@@ -26,7 +26,7 @@
                 </div>
                 <div class="col-md-6">
                     <div class="card">
-                        <a href="{{ tolatrack_url }}" class="logo-app text-center">
+                        <a href="{{ tolatrack_url }}/login/tola" class="logo-app text-center">
                             <img src="{{ STATIC_URL }}v2-assets/src/img/svg-track.svg" height="46" class="logo-app__image">
                             <span class="logo-app__caption">Track</span>
                         </a>

--- a/tola/forms.py
+++ b/tola/forms.py
@@ -100,7 +100,6 @@ class NewTolaUserRegistrationForm(forms.ModelForm):
     helper.layout = Layout(
         Fieldset('Information','title', 'org'),
         Fieldset('Privacy Statement','privacy_disclaimer_accepted',),
-
     )
 
 class BookmarkForm(forms.ModelForm):


### PR DESCRIPTION
## Purpose
When a user is created in Activity, it should be created in Track with the same UUID.

Related issue: TolaDataV2/[#465](https://github.com/toladata/TolaDataV2/issues/465)