### PR TITLE
Run drone.io tests with Postgres

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,6 +7,12 @@ pipeline:
       - python manage.py test
     when:
       event: [push, tag]
+    environment:
+      - TOLA_DB_ENGINE=django.db.backends.postgresql_psycopg2
+      - TOLA_DB_NAME=tola_activity
+      - TOLA_DB_USER=root
+      - TOLA_DB_PASS=root
+      - TOLA_DB_HOST=postgres
   build-docker-image:
     image: plugins/docker
     insecure: true
@@ -45,6 +51,14 @@ pipeline:
       status: [failure]
       event: [push, tag]
       branches: [master, dev-v2]
+
+services:
+  postgres:
+    image: postgres:9.6
+    environment:
+      - POSTGRES_DB=tola_activity
+      - POSTGRES_USER=root
+      - POSTGRES_PASSWORD=root
 
 matrix:
   PYTHON_VERSION:

--- a/tola/settings/local.py
+++ b/tola/settings/local.py
@@ -10,7 +10,7 @@ try:
             'USER': os.environ["TOLA_DB_USER"],
             'PASSWORD': os.environ.get("TOLA_DB_PASS"),
             'HOST': os.environ.get("TOLA_DB_HOST", "localhost"),
-            'PORT': os.environ["TOLA_DB_PORT"],
+            'PORT': os.environ.get("TOLA_DB_PORT", 5432),
         }
     }
 except KeyError:


### PR DESCRIPTION
## Purpose
SQLite doesn't support the Django JSONField, so we need to start running drone.io tests with Postgres.