### PR TITLE
Fix the CustomForm migration script

### DIFF
--- a/formlibrary/migrations/0005_auto_20171204_0203.py
+++ b/formlibrary/migrations/0005_auto_20171204_0203.py
@@ -18,6 +18,11 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='customform',
             name='form_uuid',
+            field=models.CharField(default='', max_length=255, verbose_name='CustomForm UUID'),
+        ),
+        migrations.AlterField(
+            model_name='customform',
+            name='form_uuid',
             field=models.CharField(default=uuid.uuid4, max_length=255, unique=True, verbose_name='CustomForm UUID'),
         ),
         migrations.AddField(


### PR DESCRIPTION
## Purpose
To create a unique field, we need to create the field first and then change it to be unique.