### PR TITLE
Fix customform migration

### DIFF
--- a/formlibrary/migrations/0005_auto_20171204_0203.py
+++ b/formlibrary/migrations/0005_auto_20171204_0203.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 import django.db.models.deletion
-import uuid
 
 
 class Migration(migrations.Migration):

--- a/formlibrary/migrations/0006_auto_20171206_0942.py
+++ b/formlibrary/migrations/0006_auto_20171206_0942.py
@@ -6,6 +6,13 @@ from django.db import migrations, models
 import uuid
 
 
+def set_form_uuid(apps, schema_editor):
+    CustomForm = apps.get_model('formlibrary', 'CustomForm')
+    for customform in CustomForm.objects.all():
+        customform.form_uuid = uuid.uuid4()
+        customform.save()
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -13,6 +20,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunPython(set_form_uuid),
         migrations.AlterField(
             model_name='customform',
             name='form_uuid',


### PR DESCRIPTION
## Purpose
We have to set the `form_uuid` field with unique values before altering it to be unique.