### PR TITLE
Reset SQL sequences after loading initial data

### DIFF
--- a/tola/management/commands/loadinitialdata.py
+++ b/tola/management/commands/loadinitialdata.py
@@ -1,8 +1,11 @@
+from cStringIO import StringIO
 import logging
+import os
 import sys
 
+from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
-from django.db import transaction, IntegrityError
+from django.db import transaction, IntegrityError, connection
 
 import factories
 from workflow.models import (
@@ -25,6 +28,8 @@ class Command(BaseCommand):
     should be empty. Otherwise the command will exit with an error and no
     new data will be added to the database.
     """
+    APPS = ('workflow', 'formlibrary', 'customdashboard', 'reports', 'gladmap',
+            'search')
 
     def __init__(self):
         # Note: for the lists we fill the first element with an empty value for
@@ -2360,6 +2365,33 @@ class Command(BaseCommand):
             role=self._groups[3],  # 3
         )
 
+    def _reset_sql_sequences(self):
+        """
+        After adding to database all rows using hardcoded IDs, the primary key
+        counter of each table is not autoupdated. This method resets all
+        primary keys for all affected apps.
+        """
+        os.environ['DJANGO_COLORS'] = 'nocolor'
+
+        for app in self.APPS:
+            buf = StringIO()
+            call_command('sqlsequencereset', app, stdout=buf)
+
+            buf.seek(0)
+            sql_commands = buf.getvalue().splitlines()
+
+            sql_commands_clean = []
+            for command in sql_commands:
+                # As we are already inside a transaction thanks to the
+                # transaction.atomic decorator, we don't need
+                # the COMMIT and BEGIN statements. If there was some problem
+                # we are automatically rolling back the transaction.
+                if command not in ('COMMIT;', 'BEGIN;'):
+                    sql_commands_clean.append(command)
+
+            cursor = connection.cursor()
+            cursor.execute("\n".join(sql_commands_clean))
+
     def add_arguments(self, parser):
         parser.add_argument('--demo', action='store_true',
                             help='Loads extra demo data')
@@ -2394,3 +2426,5 @@ class Command(BaseCommand):
                 logger.error(msg)
                 sys.stderr.write("{}\n".format(msg))
                 raise
+
+        self._reset_sql_sequences()

--- a/tola/management/commands/tests/test_loadinitialdata.py
+++ b/tola/management/commands/tests/test_loadinitialdata.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.models import Group, User
 from django.core.management import call_command
-from django.db import IntegrityError
+from django.db import IntegrityError, connection
 from django.test import TestCase
 
 from indicators.models import IndicatorType
@@ -52,6 +52,18 @@ class LoadInitialDataTest(TestCase):
         User.objects.get(first_name="Andrew", last_name="Ham")
         WorkflowLevel1.objects.get(name='Financial Assistance and Building '
                                    'Resilience in Conflict Areas')
+
+    def test_load_demo_data_check_indices_reset(self):
+        args = ['--demo']
+        opts = {}
+        call_command('loadinitialdata', *args, **opts)
+
+        cursor = connection.cursor()
+        cursor.execute("SELECT nextval('workflow_country_id_seq')")
+        self.assertNotEqual(int(cursor.fetchone()[0]), 1)
+
+        cursor.execute("SELECT nextval('workflow_workflowteam_id_seq')")
+        self.assertNotEqual(int(cursor.fetchone()[0]), 1)
 
     def test_load_demo_data_two_times_crashes_but_db_keeps_consistent(self):
         args = ['--demo']


### PR DESCRIPTION
Purpose
======

Now when we load the initial data through the factories, we set hardcoded IDs for each new record, but the database keeps the sequence at id=1.