### PR TITLE
Fallback to user's name when printing TolaUser instance

### DIFF
--- a/workflow/models.py
+++ b/workflow/models.py
@@ -220,7 +220,15 @@ class TolaUser(models.Model):
         ordering = ('name',)
 
     def __unicode__(self):
-        return self.name if self.name is not None else '-'
+        if (settings.TOLAUSER_OFUSCATED_NAME and
+                    self.name == settings.TOLAUSER_OFUSCATED_NAME):
+            if self.user.first_name and self.user.last_name:
+                return u'{} {}'.format(self.user.first_name,
+                                       self.user.last_name)
+            else:
+                return u'-'
+        else:
+            return self.name if self.name else u'-'
 
     @property
     def countries_list(self):

--- a/workflow/test_models.py
+++ b/workflow/test_models.py
@@ -16,7 +16,29 @@ class TolaUserTest(TestCase):
         self.assertEqual(tola_user.name, 'Fake Name')
 
     def test_save_without_ofuscate_name(self):
-
         tola_user = TolaUser.objects.create(name='Thom Yorke', user=self.user,
                                             organization=self.organization)
         self.assertEqual(tola_user.name, 'Thom Yorke')
+
+    def test_print_instance_no_name(self):
+        tolauser = factories.TolaUser(name=None)
+        self.assertEqual(unicode(tolauser), u'-')
+
+    def test_print_instance_empty_name(self):
+        tolauser = factories.TolaUser(name='')
+        self.assertEqual(unicode(tolauser), u'-')
+
+    def test_print_instance_name(self):
+        tolauser = factories.TolaUser(name='Daniel Avery')
+        self.assertEqual(unicode(tolauser), u'Daniel Avery')
+
+    @override_settings(TOLAUSER_OFUSCATED_NAME='Fake Name')
+    def test_print_instance_with_ofuscated_name_and_fallback(self):
+        tolauser = factories.TolaUser()
+        self.assertEqual(unicode(tolauser), u'Thom Yorke')
+
+    @override_settings(TOLAUSER_OFUSCATED_NAME='Fake Name')
+    def test_print_instance_with_ofuscated_name_without_fallback(self):
+        user = factories.User(first_name='', last_name='')
+        tolauser = factories.TolaUser(user=user)
+        self.assertEqual(unicode(tolauser), u'-')


### PR DESCRIPTION
Purpose
======

In Demo environment, it's really annoying to see something like this:

![image](https://user-images.githubusercontent.com/23944/33827337-4d0e3882-de68-11e7-8ea1-14b6d65ce375.png)

Fallback to user's first and last name when the user is obfuscated.

Ticket
====

Sorry, no ticket.