### PR TITLE
Update the error response of white-listed domain

### DIFF
--- a/templates2/unauthorized.html
+++ b/templates2/unauthorized.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="app-page">
+    <img src="{{ STATIC_URL }}v2-assets/src/img/t-shape-colors.svg" alt="" class="mx-auto login__logo">
+
+    <h3 class="text-center">TolaData</h3>
+    <div class="message mt-5">
+        <h4 class="text-center">Your organization doesn't appear to have permissions to access the system.</h4>
+        <p class="text-center">Please check with your organization to have access.</p>
+    </div>
+</div>
+{% endblock content %}

--- a/tola/auth_pipeline.py
+++ b/tola/auth_pipeline.py
@@ -1,6 +1,6 @@
-from social_core.exceptions import AuthForbidden
-
 from django.contrib.sites.shortcuts import get_current_site
+
+from django.shortcuts import render
 
 from workflow.models import Country, TolaUser, TolaSites, Organization
 
@@ -47,4 +47,4 @@ def auth_allowed(backend, details, response, *args, **kwargs):
         allowed = email in emails or domain in domains
 
     if not allowed:
-        raise AuthForbidden(backend)
+        return render(response, 'unauthorized.html')

--- a/tola/tests/test_oauth.py
+++ b/tola/tests/test_oauth.py
@@ -104,8 +104,12 @@ class OAuthTest(TestCase):
         details = {'email': self.tola_user.user.email}
         self.site.whitelisted_domains = 'anotherdomain.com'
         self.site.save()
-        with self.assertRaises(AuthForbidden):
-            auth_pipeline.auth_allowed(backend, details, None)
+        response = auth_pipeline.auth_allowed(backend, details, None)
+        template_content = response.content
+        self.assertIn("Your organization doesn't appear to have permissions "
+                      "to access the system.", template_content)
+        self.assertIn("Please check with your organization to have access.",
+                      template_content)
 
     def test_auth_allowed_no_whitelist(self):
         # Fake backend class for the test
@@ -122,5 +126,9 @@ class OAuthTest(TestCase):
 
         backend = BackendTest()
         details = {'email': self.tola_user.user.email}
-        with self.assertRaises(AuthForbidden):
-            auth_pipeline.auth_allowed(backend, details, None)
+        response = auth_pipeline.auth_allowed(backend, details, None)
+        template_content = response.content
+        self.assertIn("Your organization doesn't appear to have permissions "
+                      "to access the system.", template_content)
+        self.assertIn("Please check with your organization to have access.",
+                      template_content)


### PR DESCRIPTION
## Purpose
The response when a user isn't in the white-listed domains should be more friendly than an error in the browser.

Related ticket: TolaDataV2?[#657](https://github.com/toladata/TolaDataV2/issues/657)