### PR TITLE
Fix user sync track

### DIFF
--- a/tola/auth_pipeline.py
+++ b/tola/auth_pipeline.py
@@ -1,9 +1,11 @@
-from django.contrib.sites.shortcuts import get_current_site
+import random
 
+from django.contrib.sites.shortcuts import get_current_site
 from django.conf import settings
 from django.shortcuts import render_to_response
 
 from workflow.models import Country, TolaUser, TolaSites, Organization
+from tola.util import register_in_track
 
 
 def redirect_after_login(strategy, *args, **kwargs):
@@ -25,6 +27,20 @@ def user_to_tola(backend, user, response, *args, **kwargs):
         userprofile.name = response.get('displayName')
         userprofile.email = response.get('emails["value"]')
         userprofile.save()
+
+        generated_pass = '%032x' % random.getrandbits(128)
+        data = {
+            'username': user.username,
+            'first_name': user.first_name,
+            'last_name': user.last_name,
+            'password1': generated_pass,
+            'password2': generated_pass,
+            'title': userprofile.title,
+            'org': userprofile.organization,
+            'email': userprofile.email,
+            'tola_user_uuid': userprofile.tola_user_uuid
+        }
+        register_in_track(data, userprofile)
 
 
 def auth_allowed(backend, details, response, *args, **kwargs):

--- a/tola/tests/test_oauth.py
+++ b/tola/tests/test_oauth.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from django.test import Client
 from django.contrib.sites.shortcuts import get_current_site
 
-from social_core.exceptions import AuthForbidden
+from mock import Mock, patch
 
 from workflow.models import TolaUser
 from tola import auth_pipeline
@@ -48,7 +48,10 @@ class OAuthTest(TestCase):
             response, "value=\"CXGVOGFnTAt5cQW6m5AxbGrRq1lzKNSrou31dWm9\"")
         self.assertEqual(response.status_code, 200)
 
-    def test_user_to_tola(self):
+    @patch('tola.util.requests')
+    def test_user_to_tola(self, mock_requests):
+        mock_requests.post.return_value = Mock(status_code=201)
+
         # TolaUser will be created with default Org
         response = {
             'displayName': 'Foo Bar',

--- a/tola/tests/test_util.py
+++ b/tola/tests/test_util.py
@@ -1,0 +1,84 @@
+import json
+
+from django.test import RequestFactory, TestCase, override_settings
+from mock import Mock, patch
+
+import factories
+from tola.util import register_in_track
+
+
+# TODO Extend Util tests
+
+
+class RegisterInTrackTest(TestCase):
+    def setUp(self):
+        factories.Group()
+        self.tola_user = factories.TolaUser(user=factories.User())
+        self.factory = RequestFactory()
+
+    @override_settings(TOLA_TRACK_URL='https://tolatrack.com')
+    @override_settings(TOLA_TRACK_TOKEN='TheToken')
+    @patch('tola.util.requests')
+    def test_response_201_create(self, mock_requests):
+        external_response = {
+            'url': 'http://testserver/api/tolauser/2',
+            'tola_user_uuid': 1234567890,
+            'name': 'John Lennon',
+        }
+        mock_requests.post.return_value = Mock(
+            status_code=201, content=json.dumps(external_response))
+
+        self.tola_user.user.is_staff = True
+        self.tola_user.user.is_superuser = True
+        self.tola_user.user.save()
+
+        user = factories.User(first_name='John', last_name='Lennon')
+        tolauser = factories.TolaUser(user=user, tola_user_uuid=1234567890)
+        data = {
+            'first_name': user.first_name,
+            'last_name': user.last_name,
+            'email': user.email,
+            'username': user.username,
+            'tola_user_uuid': tolauser.tola_user_uuid
+        }
+
+        response = register_in_track(data, tolauser)
+        result = json.loads(response.content)
+
+        self.assertEqual(result['tola_user_uuid'], 1234567890)
+        mock_requests.post.assert_called_once_with(
+            'https://tolatrack.com/accounts/register/',
+            data={'username': 'johnlennon',
+                  'first_name': 'John',
+                  'last_name': 'Lennon',
+                  'tola_user_uuid': tolauser.tola_user_uuid,
+                  'email': 'johnlennon@testenv.com'},
+            headers={'Authorization': 'Token TheToken'})
+
+    @override_settings(TOLA_TRACK_URL='https://tolatrack.com')
+    @override_settings(TOLA_TRACK_TOKEN='TheToken')
+    @patch('tola.util.requests')
+    def test_response_403_forbidden(self, mock_requests):
+        mock_requests.post.return_value = Mock(status_code=403)
+
+        user = factories.User(first_name='John', last_name='Lennon')
+        tolauser = factories.TolaUser(user=user)
+        data = {
+            'first_name': user.first_name,
+            'last_name': user.last_name,
+            'email': user.email,
+            'username': user.username,
+            'tola_user_uuid': tolauser.tola_user_uuid
+        }
+
+        response = register_in_track(data, tolauser)
+
+        self.assertTrue(isinstance(response.content, Mock))
+        mock_requests.post.assert_called_once_with(
+            'https://tolatrack.com/accounts/register/',
+            data={'username': 'johnlennon',
+                  'first_name': 'John',
+                  'last_name': 'Lennon',
+                  'tola_user_uuid': tolauser.tola_user_uuid,
+                  'email': 'johnlennon@testenv.com'},
+            headers={'Authorization': 'Token TheToken'})

--- a/tola/util.py
+++ b/tola/util.py
@@ -1,10 +1,13 @@
 import unicodedata
 import json
 import requests
+import logging
+from urlparse import urljoin
 
 from workflow.models import (Country, TolaUser, TolaSites, WorkflowTeam,
                              WorkflowLevel1, Organization)
 from django.contrib.auth.models import User
+from django.conf import settings
 from django.core.mail import mail_admins, EmailMessage
 from django.core.exceptions import PermissionDenied
 from django.contrib.auth.decorators import user_passes_test
@@ -116,3 +119,23 @@ def group_required(*group_names, **url):
             raise PermissionDenied
         return False
     return user_passes_test(in_groups)
+
+
+def register_in_track(data, tolauser):
+        headers = {
+            'Authorization': 'Token {}'.format(settings.TOLA_TRACK_TOKEN),
+        }
+
+        url_subpath = 'accounts/register/'
+        url = urljoin(settings.TOLA_TRACK_URL, url_subpath)
+
+        response = requests.post(url, data=data, headers=headers)
+        logger = logging.getLogger(__name__)
+        if response.status_code == 201:
+            logger.info("The TolaUser %s (id=%s) was created successfully in "
+                        "Track." % (tolauser.name, tolauser.id))
+        elif response.status_code in [400, 403]:
+            logger.warning("The TolaUser %s (id=%s) could not be created "
+                           "successfully in Track." %
+                           (tolauser.name, tolauser.id))
+        return response

--- a/tola/views.py
+++ b/tola/views.py
@@ -1,7 +1,7 @@
 import json
 from urlparse import urljoin
 import warnings
-import logging
+import requests
 
 from django.conf import settings
 from django.contrib import messages
@@ -16,8 +16,8 @@ from django.views.generic.base import TemplateView, View
 from django.views.generic.edit import CreateView, UpdateView, DeleteView
 from django.views.generic.list import ListView
 from oauth2_provider.views.generic import ProtectedResourceView
-import requests
 
+from tola.util import register_in_track
 from feed.serializers import TolaUserSerializer, OrganizationSerializer, \
     CountrySerializer
 from tola.forms import RegistrationForm, NewUserRegistrationForm, \
@@ -88,7 +88,9 @@ class RegisterView(View):
             tolauser.organization = form_tolauser.cleaned_data.get('org')
             tolauser.name = ' '.join([user.first_name, user.last_name]).strip()
             tolauser.save()
-            self.register_in_track(request, tolauser)
+            data = request.POST.copy().dict()
+            data.update({'tola_user_uuid': tolauser.tola_user_uuid})
+            register_in_track(data, tolauser)
             messages.error(
                 request,
                 'Thank you, You have been registered as a new user.',
@@ -100,27 +102,6 @@ class RegisterView(View):
             'form_tolauser': form_tolauser,
         })
         return render(request, self.template_name, context)
-
-    def register_in_track(self, request, tolauser):
-        headers = {
-            'Authorization': 'Token {}'.format(settings.TOLA_TRACK_TOKEN),
-        }
-
-        data = request.POST.copy().dict()
-        data.update({'tola_user_uuid': tolauser.tola_user_uuid})
-        url_subpath = 'accounts/register/'
-        url = urljoin(settings.TOLA_TRACK_URL, url_subpath)
-
-        response = requests.post(url, data=data, headers=headers)
-        logger = logging.getLogger(__name__)
-        if response.status_code == 201:
-            logger.info("The TolaUser %s (id=%s) was created successfully in "
-                        "Track." % (tolauser.name, tolauser.id))
-        elif response.status_code in [400, 403]:
-            logger.warning("The TolaUser %s (id=%s) could not be created "
-                           "successfully in Track." %
-                           (tolauser.name, tolauser.id))
-        return response
 
 
 def profile(request):


### PR DESCRIPTION
## Purpose
The auth pipeline should trigger the creation of a user in TolaTrack as the registration form does.

Related ticket: #918