### PR TITLE
Tag branch in Docker image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -21,6 +21,7 @@ pipeline:
     repo: registry.tola.io/toladata/tolaactivity
     file: Dockerfile
     tags:
+      - ${DRONE_COMMIT_BRANCH}
       - ${DRONE_COMMIT_SHA}
     secrets: [DOCKER_USERNAME, DOCKER_PASSWORD]
     when:


### PR DESCRIPTION
Purpose
====

This is mostly a test. We need to deploy docker images with branch names, in order to be able to find them easily when typing `docker ps` in the server. We need that to execute cronjobs.