### PR TITLE
Log out the users in track as well

### DIFF
--- a/tola/urls.py
+++ b/tola/urls.py
@@ -4,9 +4,7 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
-from django.views.generic import TemplateView
 from rest_framework import routers
-from rest_framework.authtoken import views as authtoken_views
 
 from formlibrary.views import BinaryFieldViewSet, binary_test
 from tola import views as tola_views
@@ -125,7 +123,7 @@ urlpatterns = [ # rest framework
 
                 # local login
                 url(r'^accounts/login/$', auth_views.login, name='login'),
-                url(r'^accounts/logout/$', auth_views.logout, {'next_page': '/'}, name='logout'),
+                url(r'^accounts/logout/$', tola_views.logout_view, name='logout'),
 
                 # accounts
                 url(r'^accounts/profile/$', tola_views.profile, name='profile'),

--- a/tola/views.py
+++ b/tola/views.py
@@ -5,6 +5,7 @@ import requests
 
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth import logout
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.models import Group
@@ -250,18 +251,17 @@ class BookmarkDelete(DeleteView):
 
 def logout_view(request):
     """
-    Logout a user
+    Logout a user in activity and track
     """
-    logout(request)
-    # Redirect to a success page.
+    # Redirect to track, so the user will
+    # be logged out there as well
+    if request.user.is_authenticated:
+        logout(request)
+        url_subpath = 'accounts/logout/'
+        url = urljoin(settings.TOLA_TRACK_URL, url_subpath)
+        return HttpResponseRedirect(url)
+
     return HttpResponseRedirect("/")
-
-from django.contrib.auth import logout
-from django.shortcuts import redirect
-
-def logout_view(request):
-    logout(request)
-    return redirect('home')
 
 
 def check_view(request):


### PR DESCRIPTION
## Purpose
When a user logs out in Activity, they should be logged out from Track as well. So, we have to send a request to Track to log them out.

Related ticket: #932 
Related PR: TolaTables/[#374](https://github.com/toladata/TolaTables/pull/374)