### PR TITLE
Update the Registratrion Form

### DIFF
--- a/tola/forms.py
+++ b/tola/forms.py
@@ -120,6 +120,8 @@ class NewTolaUserRegistrationForm(forms.ModelForm):
             self.fields['org'] = forms.CharField(
                 initial=settings.DEFAULT_ORG, disabled=True)
 
+        self.fields['privacy_disclaimer_accepted'].required = True
+
 
 class BookmarkForm(forms.ModelForm):
     """

--- a/tola/tests/test_views.py
+++ b/tola/tests/test_views.py
@@ -137,7 +137,8 @@ class RegisterViewPostTest(TestCase):
         response = view(request)
         self.assertEqual(response.status_code, 200)
         template_content = response.content
-        for field in ('username', 'password1', 'password2'):
+        for field in ('username', 'password1', 'password2',
+                      'privacy_disclaimer_accepted'):
             msg = ('<p id="error_1_id_{}" class="help-block"><strong>'
                    'This field is required.</strong></p>'.format(field))
             self.assertIn(msg, template_content)


### PR DESCRIPTION
## Purpose
The Privacy disclaimer has to be required, a user cannot register in the system without accepting the terms.

Related ticket: TolaDataV2/[#839](https://github.com/toladata/TolaActivity/issues/839)