### PR TITLE
Adjust TolaUsers Admin to Include Organization Column: Fix #219

### DIFF
--- a/workflow/admin.py
+++ b/workflow/admin.py
@@ -170,9 +170,9 @@ class TolaBookmarksAdmin(admin.ModelAdmin):
 
 
 class TolaUserAdmin(admin.ModelAdmin):
-    list_display = ('name', 'country')
+    list_display = ('name', 'country', 'organization')
     display = 'Tola User'
-    list_filter = ('country', 'user__is_staff',)
+    list_filter = ('country', 'user__is_staff', 'organization')
     search_fields = ('name', 'country__country', 'title')
 
 


### PR DESCRIPTION
Add Organization column to Tolausers admin and allow filtering the same by Organization