### PR TITLE
Sync organization between Activity and Track 

### DIFF
--- a/tola/tests/test_track_sync.py
+++ b/tola/tests/test_track_sync.py
@@ -5,7 +5,9 @@ from django.test import RequestFactory, TestCase, override_settings
 from mock import Mock, patch
 
 import factories
-from tola.track_sync import register_user, create_workflowlevel1
+from tola.track_sync import (register_user, create_workflowlevel1,
+                             create_organization, update_organization,
+                             delete_organization)
 
 
 class RegisterUserTest(TestCase):
@@ -138,3 +140,109 @@ class CreateWFL1Test(TestCase):
 
         response = create_workflowlevel1(wfl1)
         self.assertEqual(response.status_code, 400)
+
+
+class TrackOrganizationTest(TestCase):
+    def setUp(self):
+        logging.disable(logging.WARNING)
+        factories.Group()
+        self.tola_user = factories.TolaUser()
+
+    def tearDown(self):
+        logging.disable(logging.NOTSET)
+
+    @override_settings(TOLA_TRACK_URL='https://tolatrack.com')
+    @override_settings(TOLA_TRACK_TOKEN='TheToken')
+    @patch('tola.track_sync.logger')
+    @patch('tola.track_sync.requests')
+    def test_response_201_create(self, mock_requests, mock_logger):
+        mock_requests.post.return_value = Mock(status_code=201)
+
+        org = factories.Organization()
+
+        response = create_organization(org)
+        self.assertEqual(response.status_code, 201)
+        mock_logger.info.assert_called_once_with(
+            'The request for {} (id={}, model={}) was successfully executed '
+            'on Track.'.format(org.name, org.id, 'Organization'))
+
+    @override_settings(TOLA_TRACK_URL='https://tolatrack.com')
+    @override_settings(TOLA_TRACK_TOKEN='TheToken')
+    @patch('tola.track_sync.logger')
+    @patch('tola.track_sync.requests')
+    def test_response_forbidden(self, mock_requests, mock_logger):
+        mock_requests.post.return_value = Mock(status_code=403)
+
+        org = factories.Organization()
+
+        response = create_organization(org)
+        self.assertEqual(response.status_code, 403)
+        mock_logger.warning.assert_called_once_with(
+            '{} (id={}, model={}) could not be created/fetched successfully '
+            'on/from Track.'.format(org.name, org.id, 'Organization'))
+
+    @override_settings(TOLA_TRACK_URL='https://tolatrack.com')
+    @override_settings(TOLA_TRACK_TOKEN='TheToken')
+    @patch('tola.track_sync.logger')
+    @patch('tola.track_sync.requests')
+    def test_response_200_update(self, mock_requests, mock_logger):
+        mock_requests.put.return_value = Mock(status_code=200)
+
+        org = factories.Organization()
+        org.name = 'Another Org'
+        org.description = 'The Org name was changed'
+        org.save()
+
+        response = update_organization(org)
+        self.assertEqual(response.status_code, 201)
+        mock_logger.info.assert_called_once_with(
+            'The request for {} (id={}, model={}) was successfully executed '
+            'on Track.'.format(org.name, org.id, 'Organization'))
+
+    @override_settings(TOLA_TRACK_URL='https://tolatrack.com')
+    @override_settings(TOLA_TRACK_TOKEN='TheToken')
+    @patch('tola.track_sync.logger')
+    @patch('tola.track_sync.requests')
+    def test_response_forbidden(self, mock_requests, mock_logger):
+        mock_requests.put.return_value = Mock(status_code=403)
+
+        org = factories.Organization()
+        org.name = 'Another Org'
+        org.description = 'The Org name was changed'
+        org.save()
+
+        response = update_organization(org)
+        self.assertEqual(response.status_code, 403)
+        mock_logger.warning.assert_called_once_with(
+            '{} (id={}, model={}) could not be created/fetched successfully '
+            'on/from Track.'.format(org.name, org.id, 'Organization'))
+
+    @override_settings(TOLA_TRACK_URL='https://tolatrack.com')
+    @override_settings(TOLA_TRACK_TOKEN='TheToken')
+    @patch('tola.track_sync.logger')
+    @patch('tola.track_sync.requests')
+    def test_response_200_update(self, mock_requests, mock_logger):
+        mock_requests.delete.return_value = Mock(status_code=200)
+
+        org = factories.Organization()
+
+        response = delete_organization(org)
+        self.assertEqual(response.status_code, 200)
+        mock_logger.info.assert_called_once_with(
+            'The request for {} (id={}, model={}) was successfully executed '
+            'on Track.'.format(org.name, org.id, 'Organization'))
+
+    @override_settings(TOLA_TRACK_URL='https://tolatrack.com')
+    @override_settings(TOLA_TRACK_TOKEN='TheToken')
+    @patch('tola.track_sync.logger')
+    @patch('tola.track_sync.requests')
+    def test_response_forbidden(self, mock_requests, mock_logger):
+        mock_requests.delete.return_value = Mock(status_code=403)
+
+        org = factories.Organization()
+
+        response = delete_organization(org)
+        self.assertEqual(response.status_code, 403)
+        mock_logger.warning.assert_called_once_with(
+            '{} (id={}, model={}) could not be created/fetched successfully '
+            'on/from Track.'.format(org.name, org.id, 'Organization'))

--- a/tola/track_sync.py
+++ b/tola/track_sync.py
@@ -8,6 +8,7 @@ from django.conf import settings
 logger = logging.getLogger(__name__)
 
 
+# UTIL FUNCTIONS FOR SYNCHRONIZATION
 # Request wrapper for Track
 def track_request(method, url_subpath, data=None):
     headers = {
@@ -21,6 +22,8 @@ def track_request(method, url_subpath, data=None):
         response = requests.put(url, data=data, headers=headers)
     elif method == 'get':
         response = requests.get(url, params=data, headers=headers)
+    elif method == 'delete':
+        response = requests.delete(url)
     return response
 
 
@@ -29,13 +32,30 @@ def validate_response(response, obj):
     if response.status_code in [200, 201]:
         logger.info('The request for {} (id={}, model={}) was successfully '
                     'executed on Track.'.format(obj.name, obj.id,
-                                            obj.__class__.__name__))
+                                                obj.__class__.__name__))
     elif response.status_code in [400, 403, 500]:
         logger.warning("{} (id={}, model={}) could not be created/fetched "
                        "successfully on/from Track.".format(
                         obj.name, obj.id, obj.__class__.__name__))
 
 
+def _build_org_form(obj):
+    return {
+        'organization_uuid': obj.organization_uuid,
+        'name': obj.name,
+        'description': obj.description,
+        'organization_url': obj.organization_url,
+        'level_1_label': obj.level_1_label,
+        'level_2_label': obj.level_2_label,
+        'level_3_label': obj.level_3_label,
+        'level_4_label': obj.level_4_label,
+        'create_date': obj.create_date,
+        'edit_date': obj.edit_date
+    }
+
+
+# FUNCTIONS TO SYNC MODELS
+# Sync Tola Users
 def register_user(data, tolauser):
     url_subpath = 'accounts/register/'
     response = track_request('post', url_subpath, data)
@@ -43,6 +63,7 @@ def register_user(data, tolauser):
     return response
 
 
+# Sync Programs/WorkflowLevel1
 def create_workflowlevel1(obj):
     url_subpath = 'api/organization?name={}'.format(obj.organization.name)
     response = track_request('get', url_subpath)
@@ -70,4 +91,25 @@ def create_workflowlevel1(obj):
     if response.status_code == 201:
         logger.info('The Program {} (id={}) was created successfully on '
                     'Track.'.format(obj.name, obj.id))
+    return response
+
+
+# Sync Organizations
+def create_organization(obj):
+    data = _build_org_form(obj)
+    response = track_request('post', 'api/organization', data)
+    validate_response(response, obj)
+    return response
+
+
+def update_organization(obj):
+    data = _build_org_form(obj)
+    response = track_request('put', 'api/organization', data)
+    validate_response(response, obj)
+    return response
+
+
+def delete_organization(obj):
+    response = track_request('delete', 'api/organization/{}'.format(obj.id))
+    validate_response(response, obj)
     return response


### PR DESCRIPTION
## Purpose
When an organization is created or updated on Activity it should be done on Track as well.

### Further info:
@sanjuroj I think you need this feature as well to keep the organization synchronized between Activity and Track, but we don't wanna execute the sync process in local environments. Therefore, we need an env variable called APP_BRANCH for the other environments, for example, "demo" and "production". Please, be aware of this change. If you don't create this env var, the synchronization won't happen.

Related ticket: #973 