### PR TITLE
Add track_sync to pkg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         'search.management.commands.search-index',
         # tola
         'tola.__init__',
+        'tola.track_sync',
         # tola.management.commands
         'tola.management.__init__',
         'tola.management.commands.__init__',


### PR DESCRIPTION
Fixes issue in ActivityAPI:

```
$ python manage.py test -v 2
Traceback (most recent call last):
  File "manage.py", line 23, in <module>
    execute_from_command_line(sys.argv)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/django/core/management/__init__.py", line 363, in execute_from_command_line
    utility.execute()
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/django/core/management/__init__.py", line 337, in execute
    django.setup()
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/django/__init__.py", line 27, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/django/apps/registry.py", line 116, in populate
    app_config.ready()
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/workflow/apps.py", line 9, in ready
    import workflow.signals  # noqa
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/workflow/signals.py", line 12, in <module>
    from tola import DEMO_BRANCH, track_sync as tsync
ImportError: cannot import name track_sync
```