### PR TITLE
Hide social auth login buttons in demo

### DIFF
--- a/templates2/registration/login.html
+++ b/templates2/registration/login.html
@@ -17,6 +17,7 @@
               </div>
           </div>
             <p class="text-center login-page__or-seperator__wrap"> <span class="login-page__or-seperator">or</span></p>
+            {% if not is_demo_branch %}
             <div class="social-buttons row">
                 <div class="col-md-6">
                     <a href="{% url 'social:begin' 'google-oauth2' %}" class="btn btn-block  btn-social btn-social--google"><i class="icon-google"></i>Login with Google</a>
@@ -25,6 +26,7 @@
                     <a href="{% url 'social:begin' 'microsoft-graph' %}" class="btn btn-social btn-social--microsoft"><i class="icon-microsoft"></i>Login with Microsoft</a>
                 </div>
             </div>
+            {% endif %}
           <p class="mt-4 text-center">
               Don't have an account? <a href="{% url 'register' %}">Register a new TolaData Account</a><br/>
           </p>

--- a/tola/tests/test_views.py
+++ b/tola/tests/test_views.py
@@ -76,6 +76,9 @@ class IndexViewTest(TestCase):
 
 
 class LoginViewTest(TestCase):
+    def tearDown(self):
+        os.environ['APP_BRANCH'] = ''
+
     def _reload_urlconf(self):
         clear_url_caches()
         if settings.ROOT_URLCONF in sys.modules:
@@ -107,6 +110,23 @@ class LoginViewTest(TestCase):
             ('<a href="https://chargebee.com/123">'
              'Register Your Organization with TolaData</a>'),
             template_content)
+
+    def test_with_social_auth_button(self):
+        self._reload_urlconf()
+        response = self.client.get(reverse('login'), follow=True)
+        template_content = response.content
+        self.assertIn('<div class="social-buttons row">', template_content)
+        self.assertIn('<i class="icon-google"></i>', template_content)
+        self.assertIn('<i class="icon-microsoft">', template_content)
+
+    def test_without_social_auth_button(self):
+        os.environ['APP_BRANCH'] = DEMO_BRANCH
+        self._reload_urlconf()
+        response = self.client.get(reverse('login'), follow=True)
+        template_content = response.content
+        self.assertNotIn('<div class="social-buttons row">', template_content)
+        self.assertNotIn('<i class="icon-google"></i>', template_content)
+        self.assertNotIn('<i class="icon-microsoft">', template_content)
 
 
 class RegisterViewGetTest(TestCase):

--- a/tola/urls.py
+++ b/tola/urls.py
@@ -1,3 +1,5 @@
+import os
+
 from django.conf import settings
 from django.conf.urls import include, url
 from django.conf.urls.static import static
@@ -9,6 +11,7 @@ from rest_framework import routers
 from formlibrary.views import BinaryFieldViewSet, binary_test
 from tola import views as tola_views
 from feed import views as feed_views
+from tola import DEMO_BRANCH
 
 admin.autodiscover()
 admin.site.site_header = 'TolaActivity administration'
@@ -115,8 +118,10 @@ urlpatterns = [
 
     # Local login
     url(r'^accounts/login/$', auth_views.LoginView.as_view(
-        extra_context={'chargebee_signup_org_url':
-                       settings.CHARGEBEE_SIGNUP_ORG_URL}),
+        extra_context={
+            'chargebee_signup_org_url': settings.CHARGEBEE_SIGNUP_ORG_URL,
+            'is_demo_branch': os.getenv('APP_BRANCH') == DEMO_BRANCH
+        }),
         name='login'),
     url(r'^accounts/logout/$', tola_views.logout_view, name='logout'),
 

--- a/tola/views.py
+++ b/tola/views.py
@@ -27,7 +27,7 @@ from feed.serializers import TolaUserSerializer, OrganizationSerializer, \
     CountrySerializer
 from tola.forms import RegistrationForm, NewUserRegistrationForm, \
     NewTolaUserRegistrationForm, BookmarkForm
-from workflow.models import (Organization, TolaUser, TolaBookmarks,
+from workflow.models import (Organization, TolaSites, TolaUser, TolaBookmarks,
                              FormGuidance, ROLE_VIEW_ONLY, TolaSites)
 
 logger = logging.getLogger(__name__)
@@ -49,7 +49,6 @@ class IndexView(LoginRequiredMixin, TemplateView):
                 "TolaSite.front_end_url and TolaSite.tola_tables_url are "
                 "deprecated. Please, set instead TOLA_ACTIVITY_URL and "
                 "TOLA_TRACK_URL values in settings", DeprecationWarning)
-            from workflow.models import TolaSites
             tola_site = TolaSites.objects.get(name="TolaData")
             extra_context = {
                 'tolaactivity_url': tola_site.front_end_url,


### PR DESCRIPTION
## Purpose
Sales would like to capture all users who log in to the demo site, so we should hide the social auth login buttons.

### Further info
Related ticket: TolaDataV2/[#714](https://github.com/toladata/TolaDataV2/issues/714)