### PR TITLE
Add TOLA_TRACK_SYNC_ENABLED env var (default=True)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,6 +13,7 @@ pipeline:
       - TOLA_DB_USER=root
       - TOLA_DB_PASS=root
       - TOLA_DB_HOST=postgres
+      - TOLA_TRACK_SYNC_ENABLED=False
       - DEFAULT_ORG=TolaData
 
   build-docker-image:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
     - TOLA_DB_USER=postgres
     - TOLA_DB_PASS=
     - TOLA_DB_PORT=5432
+    - TOLA_TRACK_SYNC_ENABLED=False
     - ELASTICSEARCH_URL=http://127.0.0.1:9200/
     - COVERALLS_REPO_TOKEN=e4x1YSoHzZd9c7lmIu880ghTMniH24YLq
     - DEFAULT_ORG=TolaData

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -67,3 +67,4 @@ services:
       - CHARGEBEE_SIGNUP_ORG_URL=https://toladata-test.chargebee.com/hosted_pages/plans/monthly
       - CHARGEBEE_SITE_API_KEY=test_31lcdE7L3grqdkGcvy24ik3lmlJrnA0Ez
       - CHARGEBEE_SITE=toladata-test
+      - TOLA_TRACK_SYNC_ENABLED=False

--- a/tola/settings/local.py
+++ b/tola/settings/local.py
@@ -155,6 +155,7 @@ TOLA_ACTIVITY_URL = os.getenv('TOLA_ACTIVITY_URL')  # frontend URL
 
 TOLA_TRACK_URL = os.getenv('TOLA_TRACK_URL')
 TOLA_TRACK_TOKEN = os.getenv('TOLA_TRACK_TOKEN')
+TOLA_TRACK_SYNC_ENABLED = False if os.getenv('TOLA_TRACK_SYNC_ENABLED') == 'False' else True
 
 ########## END CONFIGURATION
 

--- a/workflow/signals.py
+++ b/workflow/signals.py
@@ -5,6 +5,7 @@ try:
     from chargebee import Subscription
 except ImportError:
     pass
+from django.conf import settings
 from django.contrib.auth.models import Group
 from django.db.models import signals
 from django.dispatch import receiver
@@ -195,7 +196,7 @@ def check_seats_save_user_groups(sender, instance, **kwargs):
 # ORGANIZATION SIGNALS
 @receiver(signals.post_save, sender=Organization)
 def sync_save_track_organization(sender, instance, **kwargs):
-    if os.getenv('APP_BRANCH'):
+    if settings.TOLA_TRACK_SYNC_ENABLED:
         if kwargs.get('created'):
             tsync.create_instance(instance)
         else:
@@ -204,14 +205,14 @@ def sync_save_track_organization(sender, instance, **kwargs):
 
 @receiver(signals.post_delete, sender=Organization)
 def sync_delete_track_organization(sender, instance, **kwargs):
-    if os.getenv('APP_BRANCH'):
+    if settings.TOLA_TRACK_SYNC_ENABLED:
         tsync.delete_instance(instance)
 
 
 # WORKFLOWLEVEL1 SIGNALS
 @receiver(signals.post_save, sender=WorkflowLevel1)
 def sync_save_track_workflowlevel1(sender, instance, **kwargs):
-    if os.getenv('APP_BRANCH'):
+    if settings.TOLA_TRACK_SYNC_ENABLED:
         if kwargs.get('created'):
             tsync.create_instance(instance)
         else:
@@ -220,5 +221,5 @@ def sync_save_track_workflowlevel1(sender, instance, **kwargs):
 
 @receiver(signals.post_delete, sender=WorkflowLevel1)
 def sync_delete_track_workflowlevel1(sender, instance, **kwargs):
-    if os.getenv('APP_BRANCH'):
+    if settings.TOLA_TRACK_SYNC_ENABLED:
         tsync.delete_instance(instance)


### PR DESCRIPTION
1. We need it for the ActivityAPI until we have Track working in parallel.
2. Makes it easier to develop locally.
3. In case something goes wrong with the connection with Track, it doesn't break the whole system.