### PR TITLE
Fix auth pipeline

### DIFF
--- a/tola/auth_pipeline.py
+++ b/tola/auth_pipeline.py
@@ -1,4 +1,5 @@
 import random
+import logging
 
 from django.contrib.sites.shortcuts import get_current_site
 from django.conf import settings
@@ -6,6 +7,8 @@ from django.shortcuts import render_to_response
 
 from workflow.models import Country, TolaUser, TolaSites, Organization
 from tola.track_sync import register_user
+
+logger = logging.getLogger(__name__)
 
 
 def redirect_after_login(strategy, *args, **kwargs):
@@ -49,6 +52,8 @@ def auth_allowed(backend, details, response, *args, **kwargs):
     """
     emails = backend.setting('WHITELISTED_EMAILS', [])
     domains = backend.setting('WHITELISTED_DOMAINS', [])
+    static_url = settings.STATIC_URL
+    allowed = True
 
     site = get_current_site(None)
     tola_site = TolaSites.objects.get(site=site)
@@ -56,13 +61,18 @@ def auth_allowed(backend, details, response, *args, **kwargs):
         tola_domains = ','.join(tola_site.whitelisted_domains.split())
         tola_domains = tola_domains.split(',')
         domains += tola_domains
-    email = details.get('email')
-    allowed = False
-    if email and (emails or domains):
-        domain = email.split('@', 1)[1]
-        allowed = email in emails or domain in domains
+
+    try:
+        email = details['email']
+    except KeyError:
+        logger.warning('No email was passed in the details.')
+        allowed = False
+    else:
+        if emails or domains:
+            domain = email.split('@', 1)[1]
+            allowed = email in emails or domain in domains
 
     if not allowed:
-        static_url = settings.STATIC_URL
         return render_to_response('unauthorized.html',
                                   context={'STATIC_URL': static_url})
+    return allowed

--- a/tola/tests/test_oauth.py
+++ b/tola/tests/test_oauth.py
@@ -1,7 +1,6 @@
 from django.contrib.sites.shortcuts import get_current_site
 from django.test import TestCase, Client
 from mock import Mock, patch
-from social_core.exceptions import AuthForbidden
 
 import factories
 from tola import auth_pipeline

--- a/tola/tests/test_oauth.py
+++ b/tola/tests/test_oauth.py
@@ -14,6 +14,15 @@ class OAuthTest(TestCase):
     Test cases for OAuth Provider interface
     """
 
+    # Fake backend class for the test
+    class BackendTest(object):
+        def __init__(self):
+            self.WHITELISTED_EMAILS = []
+            self.WHITELISTED_DOMAINS = []
+
+        def setting(self, name, default=None):
+            return self.__dict__.get(name, default)
+
     def setUp(self):
         self.tola_user = factories.TolaUser()
         self.org = factories.Organization()
@@ -77,30 +86,12 @@ class OAuthTest(TestCase):
         self.assertEqual(tola_user.organization.name, new_org.name)
 
     def test_auth_allowed_in_whitelist(self):
-        # Fake backend class for the test
-        class BackendTest(object):
-            def __init__(self):
-                self.WHITELISTED_EMAILS = []
-                self.WHITELISTED_DOMAINS = []
-
-            def setting(self, name, default=None):
-                return self.__dict__.get(name, default)
-
-        backend = BackendTest()
+        backend = self.BackendTest()
         details = {'email': self.tola_user.user.email}
         auth_pipeline.auth_allowed(backend, details, None)
 
     def test_auth_allowed_not_in_whitelist(self):
-        # Fake backend class for the test
-        class BackendTest(object):
-            def __init__(self):
-                self.WHITELISTED_EMAILS = []
-                self.WHITELISTED_DOMAINS = []
-
-            def setting(self, name, default=None):
-                return self.__dict__.get(name, default)
-
-        backend = BackendTest()
+        backend = self.BackendTest()
         details = {'email': self.tola_user.user.email}
         self.site.whitelisted_domains = 'anotherdomain.com'
         self.site.save()
@@ -124,7 +115,7 @@ class OAuthTest(TestCase):
         self.site.whitelisted_domains = None
         self.site.save()
 
-        backend = BackendTest()
+        backend = self.BackendTest()
         details = {'email': self.tola_user.user.email}
         response = auth_pipeline.auth_allowed(backend, details, None)
         template_content = response.content


### PR DESCRIPTION
## Purpose
When there is no whitelist defined in the system, users should be able to log in. But we're currently checking the whitelists all the time and when we don't have one, no users are allowed to sign in. This was fixed!

### Further info
Related ticket: #987 