### PR TITLE
Revise chargebee url

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -64,7 +64,7 @@ services:
       - TOLA_ACTIVITY_URL=http://tolaactivity.dev.com
       - TOLA_TRACK_URL=http://tolatrack.dev.com
       - DEFAULT_ORG=TolaData
-      - CHARGEBEE_SIGNUP_ORG_URL=https://toladata-test.chargebee.com/hosted_pages/plans/monthly
+      - CHARGEBEE_SIGNUP_ORG_URL=https://toladata-test.chargebee.com/hosted_pages/plans/monthly?addons[id][0]=user&addons[quantity][0]=1
       - CHARGEBEE_SITE_API_KEY=test_31lcdE7L3grqdkGcvy24ik3lmlJrnA0Ez
       - CHARGEBEE_SITE=toladata-test
       - TOLA_TRACK_SYNC_ENABLED=False


### PR DESCRIPTION
## Purpose
We need to change the ChargeBee URL, so new organizations can add coupons and add-ons.

### Further info
Related ticket: #997 