### PR TITLE
Fix auth allowed pipeline

### DIFF
--- a/tola/auth_pipeline.py
+++ b/tola/auth_pipeline.py
@@ -75,4 +75,3 @@ def auth_allowed(backend, details, response, *args, **kwargs):
     if not allowed:
         return render_to_response('unauthorized.html',
                                   context={'STATIC_URL': static_url})
-    return allowed

--- a/tola/tests/test_oauth.py
+++ b/tola/tests/test_oauth.py
@@ -94,7 +94,7 @@ class OAuthTest(TestCase):
         backend = self.BackendTest()
         details = {'email': self.tola_user.user.email}
         result = auth_pipeline.auth_allowed(backend, details, None)
-        self.assertTrue(result)
+        self.assertIsNone(result)
 
     def test_auth_allowed_not_in_whitelist(self):
         backend = self.BackendTest()
@@ -115,7 +115,7 @@ class OAuthTest(TestCase):
         backend = self.BackendTest()
         details = {'email': self.tola_user.user.email}
         result = auth_pipeline.auth_allowed(backend, details, None)
-        self.assertTrue(result)
+        self.assertIsNone(result)
 
     def test_auth_allowed_no_email(self):
         backend = self.BackendTest()


### PR DESCRIPTION
## Purpose
Fixes the exception when logging with Google:

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "/usr/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python2.7/site-packages/django/views/decorators/cache.py", line 57, in _wrapped_view_func
    response = view_func(request, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/social_django/utils.py", line 50, in wrapper
    return func(request, backend, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/social_django/views.py", line 32, in complete
    redirect_name=REDIRECT_FIELD_NAME, *args, **kwargs)
  File "/code/src/social-core/social_core/actions.py", line 41, in do_complete
    user = backend.complete(user=user, *args, **kwargs)
  File "/code/src/social-core/social_core/backends/base.py", line 40, in complete
    return self.auth_complete(*args, **kwargs)
  File "/code/src/social-core/social_core/utils.py", line 252, in wrapper
    return func(*args, **kwargs)
  File "/code/src/social-core/social_core/backends/oauth.py", line 399, in auth_complete
    *args, **kwargs)
  File "/code/src/social-core/social_core/utils.py", line 252, in wrapper
    return func(*args, **kwargs)
  File "/code/src/social-core/social_core/backends/oauth.py", line 410, in do_auth
    return self.strategy.authenticate(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/social_django/strategy.py", line 115, in authenticate
    return authenticate(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/django/contrib/auth/__init__.py", line 77, in authenticate
    user.backend = backend_path
AttributeError: 'bool' object has no attribute 'backend'
```

## Approach
Return value for this method can be only None if success.

_Related ticket: None_
