### PR TITLE
Sync the WorkflowLevel2 and TolaUser models

### DIFF
--- a/tola/management/commands/synctrack.py
+++ b/tola/management/commands/synctrack.py
@@ -1,6 +1,5 @@
 import json
 import requests
-import uuid
 import logging
 import sys
 from urlparse import urljoin
@@ -8,7 +7,7 @@ from urlparse import urljoin
 from django.core.management.base import BaseCommand
 from django.conf import settings
 
-from workflow.models import Organization, WorkflowLevel1
+from workflow.models import Organization, WorkflowLevel1, WorkflowLevel2
 
 logger = logging.getLogger(__name__)
 
@@ -36,64 +35,51 @@ class Command(BaseCommand):
 
         return headers
 
-    def _request_to_track(self, section, payload, id):
+    def _get_from_track(self, section, name):
         """
-        send the requests to individual API endpoint in Track
-        with the payload and id
-        :param section: model class on Track and activity
-        :return: status: success of failure of request
-        """
-        headers = self._get_headers()
-
-        # Try to update if there is an instance in Track
-        url_subpath = 'api/{}/{}'.format(section, id)
-        put_url = urljoin(settings.TOLA_TRACK_URL, url_subpath)
-        response = requests.put(put_url, json=payload, headers=headers,
-                                verify=False)
-
-        if response.status_code == 404:
-            post_url = urljoin(settings.TOLA_TRACK_URL,
-                               'api/{}'.format(section))
-            response = requests.post(post_url, json=payload, headers=headers,
-                                     verify=False)
-
-        return response
-
-    def _check_instance(self, section, name):
-        """
-        Get or create the instance in Track
+        Get the instance ID from Track based on the name
         :param section:
         :param name:
         :return: the Track instance id
         """
         headers = self._get_headers()
-
-        # Check if there is an instance in Track
         url_subpath = 'api/{}?format=json&name={}'.format(section, name)
-        check_url = urljoin(settings.TOLA_TRACK_URL, url_subpath)
-        check_resp = requests.get(check_url, headers=headers, verify=False)
-        data = json.loads(check_resp.content)
+        url = urljoin(settings.TOLA_TRACK_URL, url_subpath)
+        response = requests.get(url, headers=headers, verify=False)
+        data = json.loads(response.content)
+        return data[0]
 
-        # If there is no instance in Track, we'll create it
-        if not data:
-            post_url = urljoin(settings.TOLA_TRACK_URL,
-                               'api/{}'.format(section))
-            payload = {}
-            if section == 'organization':
-                payload = {
-                    'name': name,
-                }
-            elif section == 'workflowlevel1':
-                payload = {
-                    'level1_uuid': uuid.uuid4().__str__(),
-                    'name': name,
-                }
-            post_resp = requests.post(post_url, json=payload, headers=headers,
-                                      verify=False)
-            # get data response from post
-            data = [json.loads(post_resp.content)]
+    def _create_or_update(self, section, name, payload):
+        """
+        Create or update the instance in Track
+        :param section:
+        :param name:
+        :param payload:
+        :return: the Track instance id
+        """
+        instance_id = None
+        headers = self._get_headers()
+        data = self._get_from_track(section, name)
+        if data:
+            instance_id = data['id']
 
-        instance_id = str(data[0]['id'])
+        # Update if there is an instance in Track, otherwise we'll create one
+        if not instance_id:
+            url_subpath = 'api/{}'.format(section)
+            url = urljoin(settings.TOLA_TRACK_URL, url_subpath)
+            response = requests.post(url, json=payload, headers=headers,
+                                     verify=False)
+        else:
+            url_subpath = 'api/{}/{}'.format(section, instance_id)
+            url = urljoin(settings.TOLA_TRACK_URL, url_subpath)
+            response = requests.put(url, json=payload, headers=headers,
+                                    verify=False)
+
+        if response.status_code in [200, 201]:
+            data = json.loads(response.content)
+            instance_id = str(data['id'])
+        else:
+            return None
         return instance_id
 
     def save_wfl1(self):
@@ -107,8 +93,9 @@ class Command(BaseCommand):
         # each level1 send to Track
         for program in programs:
             sys.stdout.write('.')
-            org_id = self._check_instance('organization',
-                                         program.organization.name)
+            data = self._get_from_track('organization',
+                                        program.organization.name)
+            org_id = data['id']
 
             # set payload and deliver
             payload = {
@@ -116,13 +103,39 @@ class Command(BaseCommand):
                 'name': program.name,
                 'organization': org_id,
             }
+            wfl1_id = self._create_or_update('workflowlevel1', program.name,
+                                             payload)
 
-            self._request_to_track(section='workflowlevel1',
-                                   payload=payload,
-                                   id=program.id)
-            updated_wfl1s.append(str(program.id))
+            updated_wfl1s.append(wfl1_id)
         sys.stdout.write('\n')
         return updated_wfl1s
+
+    def save_wfl2(self):
+        """
+        Update or create each workflowlevel2 in Track
+        """
+        # update TolaTrack with program data
+        projects = WorkflowLevel2.objects.all()
+        updated_wfl2s = []
+
+        # each level1 send to Track
+        for project in projects:
+            sys.stdout.write('.')
+            data = self._get_from_track('workflowlevel1',
+                                        project.workflowlevel1.name)
+            wfl1_id = data['id']
+
+            # set payload and deliver
+            payload = {
+                'level2_uuid': project.level2_uuid,
+                'name': project.name,
+                'workflowlevel1': wfl1_id,
+            }
+
+            self._create_or_update('workflowlevel2', project.name, payload)
+            updated_wfl2s.append(project.id)
+        sys.stdout.write('\n')
+        return updated_wfl2s
 
     def save_org(self):
         """
@@ -135,7 +148,6 @@ class Command(BaseCommand):
         # each level1 send to Track
         for org in orgs:
             sys.stdout.write('.')
-            org_id = self._check_instance('organization', org.name)
 
             # set payload and send to Track
             payload = {
@@ -148,10 +160,8 @@ class Command(BaseCommand):
                 'level_3_label': org.level_3_label,
                 'level_4_label': org.level_4_label,
             }
-            self._request_to_track(section='organization',
-                                   payload=payload,
-                                   id=org_id)
-            updated_orgs.append(str(org.id))
+            org_id = self._create_or_update('organization', org.name, payload)
+            updated_orgs.append(org_id)
         sys.stdout.write('\n')
         return updated_orgs
 
@@ -166,10 +176,19 @@ class Command(BaseCommand):
         except Exception as e:
             logger.error(e)
 
-        sys.stdout.write('INFO: Syncing WorkflowLevels1')
+        sys.stdout.write('INFO: Syncing WorkflowLevel1s')
         try:
             result = self.save_wfl1()
             wfl1_ids = ', '.join(result)
             logger.info('The id of updated programs: {}'.format(wfl1_ids))
         except Exception as e:
             logger.error(e)
+
+        sys.stdout.write('INFO: Syncing WorkflowLevel2s')
+        try:
+            result = self.save_wfl2()
+            wfl2_ids = ', '.join(result)
+            logger.info('The id of updated projects: {}'.format(wfl2_ids))
+        except Exception as e:
+            logger.error(e)
+

--- a/tola/management/commands/tests/test_synctrack.py
+++ b/tola/management/commands/tests/test_synctrack.py
@@ -61,7 +61,10 @@ class SyncTrackTest(TestCase):
         mock_requests.post.return_value = Mock(status_code=201,
                                                content='{"id": 1}')
         command = Command()
-        data = command._get_from_track('organization', self.org.name)
+        params = {
+            'organization_uuid': self.org.organization_uuid
+        }
+        data = command._get_from_track('organization', params)
         self.assertEqual(data, {})
 
     @patch('tola.management.commands.synctrack.requests')
@@ -69,7 +72,10 @@ class SyncTrackTest(TestCase):
         mock_requests.get.return_value = Mock(status_code=200,
                                               content='[{"id": 2}]')
         command = Command()
-        data = command._get_from_track('organization', self.org.name)
+        params = {
+            'organization_uuid': self.org.organization_uuid
+        }
+        data = command._get_from_track('organization', params)
         self.assertEqual(data['id'], 2)
 
     @patch('tola.management.commands.synctrack.Command._get_from_track')
@@ -119,7 +125,7 @@ class SyncTrackTest(TestCase):
 
         command = Command()
         result = command.save_wfl2()
-        self.assertIn(self.wfl2.id, result)
+        self.assertIn(str(self.wfl2.id), result)
 
     @patch('tola.management.commands.synctrack.Command._get_from_track')
     @patch('tola.management.commands.synctrack.Command._create_or_update')
@@ -129,7 +135,7 @@ class SyncTrackTest(TestCase):
 
         command = Command()
         result = command.save_wfl1()
-        self.assertIn(self.wfl1.id, result)
+        self.assertIn(str(self.wfl1.id), result)
 
     @patch('tola.management.commands.synctrack.Command._create_or_update')
     def test_save_org(self, mock_create_or_update):
@@ -137,4 +143,4 @@ class SyncTrackTest(TestCase):
 
         command = Command()
         result = command.save_org()
-        self.assertIn(self.org.id, result)
+        self.assertIn(str(self.org.id), result)

--- a/tola/management/commands/tests/test_synctrack.py
+++ b/tola/management/commands/tests/test_synctrack.py
@@ -1,6 +1,5 @@
 import logging
 import sys
-import json
 
 from django.core.management import call_command
 from django.test import TestCase, override_settings, tag
@@ -26,6 +25,7 @@ class SyncTrackTest(TestCase):
 
         self.org = factories.Organization()
         self.wfl1 = factories.WorkflowLevel1(organization=self.org)
+        self.wfl2 = factories.WorkflowLevel2(workflowlevel1=self.wfl1)
 
     def tearDown(self):
         sys.stdout = self.old_stdout
@@ -56,63 +56,85 @@ class SyncTrackTest(TestCase):
         self.assertIn('Authorization', headers)
 
     @patch('tola.management.commands.synctrack.requests')
-    def test_check_instance_no_org(self, mock_requests):
-        mock_requests.get.return_value = Mock(status_code=200, content='[]')
+    def test_get_from_track_no_org(self, mock_requests):
+        mock_requests.get.return_value = Mock(status_code=200, content='[{}]')
         mock_requests.post.return_value = Mock(status_code=201,
                                                content='{"id": 1}')
         command = Command()
-        instance_id = command._check_instance('organization', self.org.name)
-        self.assertEqual(instance_id, '1')
+        data = command._get_from_track('organization', self.org.name)
+        self.assertEqual(data, {})
 
     @patch('tola.management.commands.synctrack.requests')
-    def test_check_instance_org(self, mock_requests):
+    def test_get_from_track_org(self, mock_requests):
         mock_requests.get.return_value = Mock(status_code=200,
                                               content='[{"id": 2}]')
         command = Command()
-        instance_id = command._check_instance('organization', self.org.name)
-        self.assertEqual(instance_id, '2')
+        data = command._get_from_track('organization', self.org.name)
+        self.assertEqual(data['id'], 2)
 
+    @patch('tola.management.commands.synctrack.Command._get_from_track')
     @patch('tola.management.commands.synctrack.requests')
-    def test_request_to_track_no_org(self, mock_requests):
-        mock_requests.put.return_value = Mock(status_code=404)
+    def test_create_or_update_no_org(self, mock_requests, mock_get_from_track):
+        mock_get_from_track.return_value = {}
         mock_requests.post.return_value = Mock(status_code=201,
                                                content='{"id": 3}')
         command = Command()
         payload = {
             'name': self.org.name,
         }
-        response = command._request_to_track('organization', payload,
-                                             self.org.id)
-        content = json.loads(response.content)
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(content['id'], 3)
+        result = command._create_or_update('organization', self.org.id, payload)
+        self.assertEqual(result, '3')
 
+    @patch('tola.management.commands.synctrack.Command._get_from_track')
     @patch('tola.management.commands.synctrack.requests')
-    def test_request_to_track_org(self, mock_requests):
+    def test_create_or_update_with_org(self, mock_requests,
+                                       mock_get_from_track):
+        mock_get_from_track.return_value = {'id': 4}
         mock_requests.put.return_value = Mock(status_code=200,
                                               content='{"id": 4}')
         command = Command()
         payload = {
             'name': self.org.name,
         }
-        response = command._request_to_track('organization', payload,
-                                             self.org.id)
-        content = json.loads(response.content)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(content['id'], 4)
+        result = command._create_or_update('organization', self.org.id, payload)
+        self.assertEqual(result, '4')
 
-    def test_save_wfl1(self):
-        Command._check_instance = Mock()
-        Command._request_to_track = Mock()
+    @patch('tola.management.commands.synctrack.Command._get_from_track')
+    @patch('tola.management.commands.synctrack.requests')
+    def test_create_or_update_failed(self, mock_requests, mock_get_from_track):
+        mock_get_from_track.return_value = {'id': 4}
+        mock_requests.put.return_value = Mock(status_code=404)
+        command = Command()
+        payload = {
+            'name': self.org.name,
+        }
+        result = command._create_or_update('organization', self.org.id, payload)
+        self.assertEqual(result, None)
+
+    @patch('tola.management.commands.synctrack.Command._get_from_track')
+    @patch('tola.management.commands.synctrack.Command._create_or_update')
+    def test_save_wfl2(self, mock_create_or_update, mock_get_from_track):
+        mock_create_or_update.return_value = self.wfl2.id
+        mock_get_from_track.return_value = {'id': self.wfl2.id}
+
+        command = Command()
+        result = command.save_wfl2()
+        self.assertIn(self.wfl2.id, result)
+
+    @patch('tola.management.commands.synctrack.Command._get_from_track')
+    @patch('tola.management.commands.synctrack.Command._create_or_update')
+    def test_save_wfl1(self, mock_create_or_update, mock_get_from_track):
+        mock_create_or_update.return_value = self.wfl1.id
+        mock_get_from_track.return_value = {'id': self.wfl1.id}
 
         command = Command()
         result = command.save_wfl1()
-        self.assertIn(str(self.wfl1.id), result)
+        self.assertIn(self.wfl1.id, result)
 
-    def test_save_org(self):
-        Command._check_instance = Mock()
-        Command._request_to_track = Mock()
+    @patch('tola.management.commands.synctrack.Command._create_or_update')
+    def test_save_org(self, mock_create_or_update):
+        mock_create_or_update.return_value = self.org.id
 
         command = Command()
         result = command.save_org()
-        self.assertIn(str(self.org.id), result)
+        self.assertIn(self.org.id, result)

--- a/tola/management/commands/tests/test_synctrack.py
+++ b/tola/management/commands/tests/test_synctrack.py
@@ -24,6 +24,7 @@ class SyncTrackTest(TestCase):
         logging.disable(logging.ERROR)
 
         self.org = factories.Organization()
+        self.tola_user = factories.TolaUser()
         self.wfl1 = factories.WorkflowLevel1(organization=self.org)
         self.wfl2 = factories.WorkflowLevel2(workflowlevel1=self.wfl1)
 
@@ -136,6 +137,17 @@ class SyncTrackTest(TestCase):
         command = Command()
         result = command.save_wfl1()
         self.assertIn(str(self.wfl1.id), result)
+
+    @patch('tola.management.commands.synctrack.Command._get_from_track')
+    @patch('tola.management.commands.synctrack.Command._create_or_update')
+    def test_save_tola_user(self, mock_create_or_update, mock_get_from_track):
+        mock_create_or_update.return_value = self.tola_user.id
+        mock_get_from_track.return_value = {'id': self.org.id,
+                                            'name': self.org.name}
+
+        command = Command()
+        result = command.save_tola_user()
+        self.assertIn(str(self.tola_user.id), result)
 
     @patch('tola.management.commands.synctrack.Command._create_or_update')
     def test_save_org(self, mock_create_or_update):


### PR DESCRIPTION
## Purpose
We have to keep the projects and Tola users up to data on Track. They should be the same in Activity and Track.

## Approach
We've already implemented a django-admin command to sync programs and organization. I just extended the functionality adding projects and tola users.

### Furter Info
- We still have to improve the command, e.g., add the delete option.

Related ticket: #994 
