### PR TITLE
Fix workflow.models unicode representation

### DIFF
--- a/workflow/models.py
+++ b/workflow/models.py
@@ -717,7 +717,8 @@ class WorkflowTeam(models.Model):
         super(WorkflowTeam, self).save()
 
     def __unicode__(self):
-        return self.workflow_user.user.first_name + " " + self.workflow_user.user.last_name
+        return u"{} - {} <{}>".format(self.workflow_user, self.role,
+                                      self.workflowlevel1)
 
 
 class AdminLevelOne(models.Model):
@@ -822,8 +823,10 @@ class Office(models.Model):
         super(Office, self).save()
 
     def __unicode__(self):
-        new_name = unicode(self.name) + unicode(" - ") + unicode(self.code)
-        return new_name
+        if not self.code:
+            return unicode(self.name)
+        else:
+            return u"{} - {}".format(self.name, self.code)
 
 
 class ProfileType(models.Model):
@@ -965,8 +968,10 @@ class Contact(models.Model):
         super(Contact, self).save()
 
     def __unicode__(self):
-        return self.name + ", " + self.title
-
+        if self.title:
+            return u"{}, {}".format(self.name, self.title)
+        else:
+            return unicode(self.name)
 
 class StakeholderType(models.Model):
     name = models.CharField("Stakeholder Type", max_length=255, blank=True, null=True)
@@ -1227,8 +1232,7 @@ class WorkflowLevel2(models.Model):
         return ', '.join([x.name for x in self.stakeholder.all()])
 
     def __unicode__(self):
-        new_name = unicode(self.office) + unicode(" - ") + unicode(self.name)
-        return new_name
+        return unicode(self.name)
 
 
 class WorkflowLevel2Sort(models.Model):

--- a/workflow/tests/test_models.py
+++ b/workflow/tests/test_models.py
@@ -1,7 +1,7 @@
 from django.test import TestCase, override_settings, tag
 
 import factories
-from workflow.models import TolaUser
+from workflow.models import TolaUser, Office
 
 
 @tag('pkg')
@@ -22,20 +22,20 @@ class TolaUserTest(TestCase):
         self.assertEqual(tola_user.name, 'Thom Yorke')
 
     def test_print_instance_no_name(self):
-        tolauser = factories.TolaUser(name=None)
+        tolauser = factories.TolaUser.build(name=None)
         self.assertEqual(unicode(tolauser), u'-')
 
     def test_print_instance_empty_name(self):
-        tolauser = factories.TolaUser(name='')
+        tolauser = factories.TolaUser.build(name='')
         self.assertEqual(unicode(tolauser), u'-')
 
     def test_print_instance_name(self):
-        tolauser = factories.TolaUser(name='Daniel Avery')
+        tolauser = factories.TolaUser.build(name='Daniel Avery')
         self.assertEqual(unicode(tolauser), u'Daniel Avery')
 
     @override_settings(TOLAUSER_OBFUSCATED_NAME='Fake Name')
     def test_print_instance_with_obfuscated_name_and_fallback(self):
-        tolauser = factories.TolaUser()
+        tolauser = factories.TolaUser.build()
         self.assertEqual(unicode(tolauser), u'Thom Yorke')
 
     @override_settings(TOLAUSER_OBFUSCATED_NAME='Fake Name')
@@ -43,3 +43,42 @@ class TolaUserTest(TestCase):
         user = factories.User(first_name='', last_name='')
         tolauser = factories.TolaUser(user=user)
         self.assertEqual(unicode(tolauser), u'-')
+
+
+@tag('pkg')
+class WorkflowTeamTest(TestCase):
+    def test_print_instance(self):
+        wfteam = factories.WorkflowTeam()
+        self.assertEqual(unicode(wfteam),
+                         (u'Thom Yorke - ProgramAdmin <Health and Survival '
+                          u'for Syrians in Affected Regions>'))
+
+
+@tag('pkg')
+class OfficeTest(TestCase):
+    def test_print_instance(self):
+        office = Office(name="Office", code="Code")
+        self.assertEqual(unicode(office), u'Office - Code')
+
+    def test_print_instance_without_code(self):
+        office = Office(name="Office", code=None)
+        self.assertEqual(unicode(office), u'Office')
+
+
+
+@tag('pkg')
+class ContactTest(TestCase):
+    def test_print_instance(self):
+        contact = factories.Contact.build(title="Title")
+        self.assertEqual(unicode(contact), u'Aryana Sayeed, Title')
+
+    def test_print_instance_without_title(self):
+        contact = factories.Contact.build()
+        self.assertEqual(unicode(contact), u'Aryana Sayeed')
+
+
+@tag('pkg')
+class WorkflowLevel2Test(TestCase):
+    def test_print_instance(self):
+        wflvl2 = factories.WorkflowLevel2.build()
+        self.assertEqual(unicode(wflvl2), u'Help Syrians')


### PR DESCRIPTION
# Purpose

Fixes errors when inside the representation string there is a None value.

# Ticket

No ticket