### PR TITLE
Fix error when updating Budget items

### DIFF
--- a/feed/tests/test_budgetview.py
+++ b/feed/tests/test_budgetview.py
@@ -137,6 +137,31 @@ class BudgetUpdateViewTest(TestCase):
         self.assertEquals(wkfl2.total_estimated_budget, data['proposed_value'])
         self.assertEquals(wkfl2.actual_cost, data['actual_value'])
 
+    def test_update_budget_without_actual_value(self):
+        wflvl1 = factories.WorkflowLevel1(
+            name='WorkflowLevel1', organization=self.tola_user.organization)
+        wflvl2 = factories.WorkflowLevel2(
+            name='WorkflowLevel2', actual_cost=100, total_estimated_budget=0,
+            workflowlevel1=wflvl1)
+        budget = factories.Budget(workflowlevel2=wflvl2,
+                                  proposed_value=None, actual_value=None)
+
+        data = {'proposed_value': 5678}
+        request = self.factory.post('/api/budget/', data)
+        request.user = self.tola_user.user
+        view = BudgetViewSet.as_view({'post': 'update'})
+        response = view(request, pk=budget.pk)
+
+        budget = Budget.objects.get(pk=response.data['id'])
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['proposed_value'], budget.proposed_value)
+        self.assertEqual(response.data['actual_value'], 0)
+
+        # Check WorkflowLevel2
+        wkfl2 = budget.workflowlevel2
+        self.assertEquals(wkfl2.total_estimated_budget, data['proposed_value'])
+        self.assertEquals(wkfl2.actual_cost, 100)
+
     def test_update_budget_without_wkfl2(self):
         budget = factories.Budget()
 

--- a/workflow/models.py
+++ b/workflow/models.py
@@ -1341,11 +1341,11 @@ class Documentation(models.Model):
 
 class Budget(models.Model):
     contributor = models.CharField(max_length=135, blank=True, null=True, help_text="Source of budget fund")
-    account_code = models.CharField("Accounting Code",max_length=135, blank=True, null=True, help_text="Label or coded field")
-    cost_center = models.CharField("Cost Center",max_length=135, blank=True, null=True, help_text="Associate a cost with a type of expense")
-    donor_code = models.CharField("Donor Code",max_length=135, blank=True, null=True, help_text="Third Party coded field")
+    account_code = models.CharField("Accounting Code", max_length=135, blank=True, null=True, help_text="Label or coded field")
+    cost_center = models.CharField("Cost Center", max_length=135, blank=True, null=True, help_text="Associate a cost with a type of expense")
+    donor_code = models.CharField("Donor Code", max_length=135, blank=True, null=True, help_text="Third Party coded field")
     description_of_contribution = models.CharField(max_length=255, blank=True, null=True, help_text="Purpose or use for funds")
-    proposed_value = models.IntegerField("Budget",default=0, blank=True, null=True, help_text="Approximate value if not a monetary fund")
+    proposed_value = models.IntegerField("Budget", default=0, blank=True, null=True, help_text="Approximate value if not a monetary fund")
     actual_value = models.IntegerField("Actual", default=0, blank=True, null=True, help_text="Monetary value positive or negative")
     workflowlevel2 = models.ForeignKey(WorkflowLevel2, blank=True, null=True, on_delete=models.SET_NULL, help_text="Releated workflow level 2")
     local_currency = models.ForeignKey(Currency, blank=True, null=True, related_name="local", help_text="Primary Currency")
@@ -1359,6 +1359,11 @@ class Budget(models.Model):
         if not self.create_date:
             self.create_date = timezone.now()
         self.edit_date = timezone.now()
+
+        if self.proposed_value is None:
+            self.proposed_value = 0
+        if self.actual_value is None:
+            self.actual_value = 0
 
         if self.workflowlevel2:
             wflvl2 = self.workflowlevel2


### PR DESCRIPTION
## Purpose
The user needs to be able to update the Budget Amount and Actual Amounts for their WFL2 budgets.

## Approach
I'm setting the default value of the fields as 0, even in the `save()` method to make sure that they won't be `None`.

### Furter Info
Related ticket: #1038 
