### PR TITLE
Wait until the postgres is ready before test running

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,6 +4,7 @@ pipeline:
     image: python:${PYTHON_VERSION}
     commands:
       - pip install -r requirements/ci.txt
+      - ./tcp-port-wait.sh postgres 5432
       - python manage.py test
     when:
       event: [push, tag]

--- a/tcp-port-wait.sh
+++ b/tcp-port-wait.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+apt update
+apt install -y netcat
+set -e
+
+if [ -z "$1" -o -z "$2" ]
+then
+    echo "tcp-port-wait - block until specified TCP port becomes available"
+    echo "Usage: ntcp-port-wait HOST PORT"
+    exit 1
+fi
+echo Waiting for port $1:$2 to become available...
+while ! nc -z $1 $2 2>/dev/null
+do
+    let elapsed=elapsed+1
+    if [ "$elapsed" -gt 120 ]
+    then
+        echo "TIMED OUT !"
+        exit 1
+    fi
+    sleep 1;
+done
+
+echo "READY !"


### PR DESCRIPTION
## Purpose
The drone will always wait for the database before starting to run the tests.

## Approach
Added a script to wait for the database for 120 seconds. If it exceeds the 2 min, it's gonna fail.
