### PR TITLE
make workflowlevel1 model uuid non-editable

### DIFF
--- a/workflow/models.py
+++ b/workflow/models.py
@@ -621,7 +621,7 @@ class Milestone(models.Model):
 
 
 class WorkflowLevel1(models.Model):
-    level1_uuid = models.CharField(max_length=255, verbose_name='WorkflowLevel1 UUID', default=uuid.uuid4, unique=True)
+    level1_uuid = models.CharField(max_length=255, editable=False, verbose_name='WorkflowLevel1 UUID', default=uuid.uuid4, unique=True)
     unique_id = models.CharField("ID", max_length=255, blank=True, null=True, help_text="User facing unique ID field if needed")
     name = models.CharField("Name", max_length=255, blank=True)
     funding_status = models.CharField("Funding Status", max_length=255, blank=True, help_text='Funds have been approved to start working')


### PR DESCRIPTION
## Purpose
Workflowlevel1 models uuid field can not be editable by  Activity API  create and update methods.

## Approach
Added editable feature to uuid field with value of False.

Related ticket: Humanitec/ActivityAPI#175
