### PR TITLE
Make unable to create workflowteam with OrgAdmin role

### DIFF
--- a/workflow/models.py
+++ b/workflow/models.py
@@ -723,6 +723,12 @@ class WorkflowTeam(models.Model):
         verbose_name = "Workflow Team"
         verbose_name_plural = "Workflow Teams"
 
+    def clean(self):
+        if self.role and self.role.name == ROLE_ORGANIZATION_ADMIN:
+            raise ValidationError(
+                'Workflowteam role can not be ROLE_ORGANIZATION_ADMIN'
+            )
+
     def save(self, *args, **kwargs):
         if self.create_date == None:
             self.create_date = timezone.now()

--- a/workflow/signals.py
+++ b/workflow/signals.py
@@ -87,6 +87,7 @@ def check_seats_save_team(sender, instance, **kwargs):
     Validate, increase or decrease the amount of used seats
     based on the roles
     """
+    instance.full_clean()
     if os.getenv('APP_BRANCH') == DEMO_BRANCH:
         return
 

--- a/workflow/tests/test_models.py
+++ b/workflow/tests/test_models.py
@@ -3,7 +3,7 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase, override_settings, tag
 
 import factories
-from workflow.models import TolaUser, Office
+from workflow.models import TolaUser, Office, ROLE_ORGANIZATION_ADMIN
 
 
 @tag('pkg')
@@ -54,6 +54,13 @@ class WorkflowTeamTest(TestCase):
         self.assertEqual(unicode(wfteam),
                          (u'Thom Yorke - ProgramAdmin <Health and Survival '
                           u'for Syrians in Affected Regions>'))
+
+    def test_save_role_org_admin_fails(self):
+        wfteam = factories.WorkflowTeam.build(
+            role=factories.Group(name=ROLE_ORGANIZATION_ADMIN),
+            workflow_user=factories.TolaUser(),
+            workflowlevel1=factories.WorkflowLevel1())
+        self.assertRaises(ValidationError, wfteam.save)
 
 
 @tag('pkg')


### PR DESCRIPTION
## Purpose
ROLE_ORGANIZATION_ADMIN cannot be use as WorkflowTeams role.

## Approach
Validation added to check WorkFlowTeam.role is not  ROLE_ORGANIZATION_ADMIN. 

Related ticket: #1075
