### PR TITLE
Fix #175 - make workflowlevel2 uuid non-editable

### DIFF
--- a/workflow/models.py
+++ b/workflow/models.py
@@ -1123,7 +1123,7 @@ class WorkflowLevel2(models.Model):
     issues_and_challenges = models.TextField("List any issues or challenges faced (include reasons for delays)", blank=True, null=True, help_text="Descriptive, what are some of the issues and challenges")
     justification_background = models.TextField("General Background and Problem Statement", blank=True, null=True, help_text="Descriptive, why are we starting this effort")
     lessons_learned = models.TextField("Lessons learned", blank=True, null=True, help_text="Descriptive, when completed what lessons were learned")
-    level2_uuid = models.CharField(max_length=255, verbose_name='WorkflowLevel2 UUID', default=uuid.uuid4, unique=True, blank=True, help_text="Unique ID")
+    level2_uuid = models.CharField(max_length=255, editable=False, verbose_name='WorkflowLevel2 UUID', default=uuid.uuid4, unique=True, blank=True, help_text="Unique ID")
     name = models.CharField("Name", max_length=255)
     notes = models.TextField(blank=True, null=True)
     parent_workflowlevel2 = models.IntegerField("Parent", default=0, blank=True)


### PR DESCRIPTION
## Purpose
Workflowlevel2 models uuid field can not be editable by Activity API create and update methods.

## Approach
editable feature added to uuid field with value of False.

_Related ticket: Humanitec/ActivityAPI#175
