### PR TITLE
 Remove Contact model from workflow module

### DIFF
--- a/factories/workflow_models.py
+++ b/factories/workflow_models.py
@@ -12,7 +12,6 @@ from workflow.models import (
     Budget as BudgetM,
     Checklist as ChecklistM,
     CodedField as CodedFieldM,
-    Contact as ContactM,
     Country as CountryM,
     Documentation as DocumentationM,
     FundCode as FundCodeM,
@@ -76,17 +75,6 @@ class Country(DjangoModelFactory):
 
     country = 'Afghanistan'
     code = 'AF'
-
-
-class Contact(DjangoModelFactory):
-    class Meta:
-        model = ContactM
-
-    name = 'Aryana Sayeed'
-    city = 'Kabul'
-    email = lazy_attribute(lambda o: slugify(o.name) + "@external-contact.com")
-    phone = '+93 555444333'
-    country = SubFactory(Country)
 
 
 class Organization(DjangoModelFactory):

--- a/workflow/admin.py
+++ b/workflow/admin.py
@@ -12,7 +12,7 @@ from .models import (Country, Documentation, WorkflowLevel2,
                      WorkflowLevel2, WorkflowLevel2Sort, Documentation,
                      SiteProfile, ProjectType,  Budget,
                      ProfileType, WorkflowTeam, ChecklistItem, Checklist,
-                     Stakeholder, Contact, StakeholderType, TolaUser, TolaSites,
+                     Stakeholder, StakeholderType, TolaUser, TolaSites,
                      FormGuidance, TolaUserProxy, TolaBookmarks, Currency,
                      ApprovalWorkflow, ApprovalType, FundCode, RiskRegister,
                      IssueRegister, CodedField, WorkflowModules, Milestone,
@@ -186,13 +186,6 @@ class ProjectTypeAdmin(admin.ModelAdmin):
     display = 'Project Type'
 
 
-class ContactAdmin(admin.ModelAdmin):
-    list_display = ('name', 'country', 'create_date', 'edit_date')
-    display = 'Contact'
-    list_filter = ('create_date','country')
-    search_fields = ('name','country','title','city')
-
-
 class FundCodeAdmin(admin.ModelAdmin):
     list_display = ('name', 'create_date', 'edit_date')
     display = 'Fund Code'
@@ -305,7 +298,6 @@ admin.site.register(WorkflowTeam, WorkflowTeamAdmin)
 admin.site.register(ChecklistItem, ChecklistItemAdmin)
 admin.site.register(Checklist, ChecklistAdmin)
 admin.site.register(Stakeholder, StakeholderAdmin)
-admin.site.register(Contact, ContactAdmin)
 admin.site.register(StakeholderType)
 admin.site.register(TolaUser, TolaUserAdmin)
 admin.site.register(TolaSites, TolaSitesAdmin)

--- a/workflow/models.py
+++ b/workflow/models.py
@@ -957,41 +957,6 @@ class SiteProfile(models.Model):
         return new_name
 
 
-class Contact(models.Model):
-    """
-    A contact is a person or entity who may be approached for information or assistance about a Site.
-
-    Example: Building Maintenance Manager at a Training Center.
-    """
-    name = models.CharField("Name", max_length=255, blank=True, null=True)
-    title = models.CharField("Title", max_length=255, blank=True, null=True)
-    city = models.CharField("City/Town", max_length=255, blank=True, null=True)
-    address = models.TextField("Address", max_length=255, blank=True, null=True)
-    email = models.CharField("Email", max_length=255, blank=True, null=True)
-    phone = models.CharField("Phone", max_length=255, blank=True, null=True)
-    country = models.ForeignKey(Country)
-    organization = models.ForeignKey(Organization, blank=True, null=True)
-    workflowlevel1 = models.ForeignKey(WorkflowLevel1, blank=True, null=True)
-    create_date = models.DateTimeField(null=True, blank=True)
-    edit_date = models.DateTimeField(null=True, blank=True)
-
-    class Meta:
-        ordering = ('name', 'country', 'title')
-        verbose_name_plural = "Contact"
-
-    # onsave add create date or update edit date
-    def save(self, *args, **kwargs):
-        if self.create_date == None:
-            self.create_date = timezone.now()
-        self.edit_date = timezone.now()
-        super(Contact, self).save()
-
-    def __unicode__(self):
-        if self.title:
-            return u"{}, {}".format(self.name, self.title)
-        else:
-            return unicode(self.name)
-
 class StakeholderType(models.Model):
     name = models.CharField("Stakeholder Type", max_length=255, blank=True, null=True)
     default_global = models.BooleanField(default=0)
@@ -1015,7 +980,7 @@ class StakeholderType(models.Model):
 
 class StakeholderManager(models.Manager):
     def get_queryset(self):
-        return super(StakeholderManager, self).get_queryset().prefetch_related('contact', 'sectors').select_related(
+        return super(StakeholderManager, self).get_queryset().prefetch_related('sectors').select_related(
             'country', 'type', 'formal_relationship_document', 'vetting_document')
 
 
@@ -1035,7 +1000,6 @@ class Stakeholder(models.Model):
     type = models.ForeignKey(StakeholderType, blank=True, null=True)
     role = models.CharField("Role", max_length=255, blank=True, null=True)
     contribution = models.CharField("Contribution", max_length=255, blank=True, null=True)
-    contact = models.ManyToManyField(Contact, max_length=255, blank=True)
     country = models.ForeignKey(Country, blank=True, null=True)
     organization = models.ForeignKey(Organization, default=1)
     workflowlevel1 = models.ManyToManyField(WorkflowLevel1, blank=True)
@@ -1071,7 +1035,6 @@ class Partner(models.Model):
     partners_uuid = models.CharField(max_length=255, verbose_name='Partner UUID', default=uuid.uuid4, unique=True)
     name = models.CharField("Partner/Organization Name", max_length=255, blank=True, null=True)
     type = models.ForeignKey(StakeholderType, blank=True, null=True, related_name="stakeholder_partner")
-    contact = models.ManyToManyField(Contact, max_length=255, blank=True)
     country = models.ForeignKey(Country, blank=True, null=True)
     sectors = models.ManyToManyField(Sector, blank=True)
     organization = models.ForeignKey(Organization, default=1)

--- a/workflow/tests/test_models.py
+++ b/workflow/tests/test_models.py
@@ -82,17 +82,6 @@ class OfficeTest(TestCase):
 
 
 @tag('pkg')
-class ContactTest(TestCase):
-    def test_print_instance(self):
-        contact = factories.Contact.build(title="Title")
-        self.assertEqual(unicode(contact), u'Aryana Sayeed, Title')
-
-    def test_print_instance_without_title(self):
-        contact = factories.Contact.build()
-        self.assertEqual(unicode(contact), u'Aryana Sayeed')
-
-
-@tag('pkg')
 class WorkflowLevel2Test(TestCase):
     def test_print_instance(self):
         wflvl2 = factories.WorkflowLevel2.build()


### PR DESCRIPTION
## Purpose
 We don't need Contact model anymore because we have Contact model on microservice. Contact endpoint already removed by @Menda . 
Remove Contact model and it's dependencies from workflow module.

## Approach
Removed codes which related to Contact model.

_Related ticket: Humanitec/ActivityAPI#172
