### PR TITLE
Install django-oauth-toolkit-jwt

### DIFF
--- a/requirements/pkg.txt
+++ b/requirements/pkg.txt
@@ -1,6 +1,7 @@
 django_admin_report==0.4
 django-import-export==0.5.1
 django-oauth-toolkit==1.1.2
+git+https://github.com/Humanitec/django-oauth-toolkit-jwt@v0.1#egg=django-oauth-toolkit-jwt
 django-simple-history==1.9.0
 elasticsearch==5.4.0
 factory_boy==2.9.2

--- a/setup.py
+++ b/setup.py
@@ -20,14 +20,23 @@ class InstallCommand(install):
 with open(join(os.path.dirname(__file__), 'README.md')) as readme:
     README = readme.read()
 
-def load_requirements():
-    return open(join(dirname(__file__), 'requirements/pkg.txt')).readlines()
+
+def load_requirements(load_dependency_links=False):
+    lines = open(join(dirname(__file__), 'requirements/pkg.txt')).readlines()
+    requirements = []
+    for line in lines:
+        if 'https' in line and load_dependency_links:
+            requirements.append(line)
+        elif 'https' not in line and not load_dependency_links:
+            requirements.append(line)
+    return requirements
 
 
 setup(
     name='tola_activity',
     version='2.0',
     install_requires=load_requirements(),
+    dependency_links=load_requirements(load_dependency_links=True),
     packages=[
         'factories',
         'formlibrary.migrations',


### PR DESCRIPTION
## Purpose
Installs extension django-oauth-toolkit-jwt

I tried locally this branch in Activity and everything is working as it was.

Related ticket: https://app.zenhub.com/workspace/o/humanitec/activityapi/issues/252
