### PR TITLE
Upgrade django-oauth-toolkit-jwt to v0.3

### DIFF
--- a/requirements/pkg.txt
+++ b/requirements/pkg.txt
@@ -1,7 +1,7 @@
 django_admin_report==0.4
 django-import-export==0.5.1
 django-oauth-toolkit==1.1.2
-git+https://github.com/Humanitec/django-oauth-toolkit-jwt@v0.2#egg=django-oauth-toolkit-jwt
+git+https://github.com/Humanitec/django-oauth-toolkit-jwt@v0.3#egg=django-oauth-toolkit-jwt
 django-simple-history==1.9.0
 elasticsearch==5.4.0
 factory_boy==2.9.2


### PR DESCRIPTION
## Purpose
Upgrades django-oauth-toolkit-jwt to v0.3.