### PR TITLE
Remove debug toolbar

### DIFF
--- a/tola/settings/dev.py
+++ b/tola/settings/dev.py
@@ -1,22 +1,5 @@
 from local import *
 
-
-DEV_APPS = (
-    'debug_toolbar',
-)
-
-INSTALLED_APPS = INSTALLED_APPS + DEV_APPS
-
-DEV_MIDDLEWARE = (
-    'debug_toolbar.middleware.DebugToolbarMiddleware',
-)
-
-MIDDLEWARE = MIDDLEWARE + DEV_MIDDLEWARE
-
-DEBUG_TOOLBAR_CONFIG = {
-    "SHOW_TOOLBAR_CALLBACK": lambda request: True,
-}
-
 DEBUG = True
 
 OFFLINE_MODE = True


### PR DESCRIPTION
## Purpose
The third party addon `debug_toolbar` has been removed from requirements but was still initialised in the settings which caused problems when creating migrations for models.

## Approach
Remove the unnecessary settings.