### PR TITLE
Add org name for WorkflowLevel1 representation

### DIFF
--- a/workflow/models.py
+++ b/workflow/models.py
@@ -677,7 +677,10 @@ class WorkflowLevel1(models.Model):
         return ', '.join([x.country for x in self.country.all()])
 
     def __unicode__(self):
-        return self.name
+        if self.organization:
+            return u"{} <{}>".format(self.name, self.organization.name)
+        else:
+            return self.name
 
 
 class WorkflowLevel1Sector(models.Model):

--- a/workflow/tests/test_models.py
+++ b/workflow/tests/test_models.py
@@ -82,6 +82,19 @@ class OfficeTest(TestCase):
 
 
 @tag('pkg')
+class WorkflowLevel1Test(TestCase):
+    def test_print_instance_no_org(self):
+        wflvl1 = factories.WorkflowLevel1.build(name='ACME', organization=None)
+        self.assertEqual(unicode(wflvl1), u'ACME')
+
+    def test_print_instance_with_org(self):
+        organization = factories.Organization(name='ACME Org')
+        wflvl1 = factories.WorkflowLevel1.build(name='ACME',
+                                                organization=organization)
+        self.assertEqual(unicode(wflvl1), u'ACME <ACME Org>')
+
+
+@tag('pkg')
 class WorkflowLevel2Test(TestCase):
     def test_print_instance(self):
         wflvl2 = factories.WorkflowLevel2.build()


### PR DESCRIPTION
## Purpose
When we have many Organizations with similar project names, it's difficult to manage them in Django Admin.