### PR TITLE
Improve data integrity when triggering signals

### DIFF
--- a/workflow/signals.py
+++ b/workflow/signals.py
@@ -128,10 +128,10 @@ def add_users_to_default_wflvl1(sender, instance, **kwargs):
 
     workflowlevel1 = WorkflowLevel1.objects.get(
         organization=instance.organization,
-        name=DEFAULT_PROGRAM_NAME)
+        name__icontains=DEFAULT_PROGRAM_NAME)
     role = Group.objects.get(name=ROLE_PROGRAM_ADMIN)
-    WorkflowTeam.objects.create(workflow_user=instance, role=role,
-                                workflowlevel1=workflowlevel1)
+    WorkflowTeam.objects.get_or_create(workflow_user=instance, role=role,
+                                       workflowlevel1=workflowlevel1)
 
 
 # ORGANIZATION SIGNALS

--- a/workflow/tests/test_signals.py
+++ b/workflow/tests/test_signals.py
@@ -153,6 +153,38 @@ class AddTolaUserAsProgramAdminTest(TestCase):
         wft = WorkflowTeam.objects.get(workflow_user=tolauser)
         self.assertEqual(wft.role, role_program_admin)
 
+    @override_settings(SET_PROGRAM_ADMIN_DEFAULT=True)
+    @override_settings(CREATE_DEFAULT_PROGRAM=True)
+    def test_activated_save_two_times(self):
+        """
+        When the TolaUser is saved, a WorkflowTeam object for that user and
+        the default program is created only once.
+        """
+        role_program_admin = factories.Group(name=ROLE_PROGRAM_ADMIN)
+        tolauser = factories.TolaUser()  # triggers the signal
+        tolauser.save()  # triggers the signal again
+        wft = WorkflowTeam.objects.get(workflow_user=tolauser)
+        self.assertEqual(wft.role, role_program_admin)
+
+    @override_settings(SET_PROGRAM_ADMIN_DEFAULT=True)
+    @override_settings(CREATE_DEFAULT_PROGRAM=True)
+    def test_activated_program_lowercase(self):
+        """
+        If the default program name is written in different case letters, the
+        signal does not crash.
+        """
+        role_program_admin = factories.Group(name=ROLE_PROGRAM_ADMIN)
+        tolauser = factories.TolaUser()  # triggers the signal
+        wflvl1 = WorkflowLevel1.objects.get(name=DEFAULT_PROGRAM_NAME)
+        wflvl1.name = DEFAULT_PROGRAM_NAME.lower()
+        wflvl1.save()
+        WorkflowTeam.objects.all().delete()
+
+        tolauser.name = 'Any'
+        tolauser.save()  # trigger again the signal
+        wft = WorkflowTeam.objects.get(workflow_user=tolauser)
+        self.assertEqual(wft.role, role_program_admin)
+
 
 @tag('pkg')
 class CheckSeatsSaveWFTeamsTest(TestCase):


### PR DESCRIPTION
## Purpose
In Kupfer we have the "Default Program" named with different letter cases sometimes, as people are introducing or modifying data manually. In this PR we ignore the case for that.

Also avoids duplication when creating WorkflowTeams after signals.

Related ticket: https://github.com/Humanitec/ActivityAPI/issues/128
