### PR TITLE
add export and import option to PeriodicTarget on admin panel

### DIFF
--- a/indicators/admin.py
+++ b/indicators/admin.py
@@ -81,6 +81,18 @@ class DisaggregationLabelAdmin(admin.ModelAdmin):
     list_display = ('disaggregation_type', 'customsort', 'label',)
     display = 'Disaggregation Label'
     list_filter = ('disaggregation_type__disaggregation_type',)
+    
+
+class PeriodicTargetResource(resources.ModelResource):
+    class Meta:
+        model = PeriodicTarget
+
+
+class PeriodicTargetAdmin(ImportExportModelAdmin):
+    resource_class = PeriodicTargetResource
+    list_display = ('period', 'target', 'customsort',)
+    display = 'Indicator Periodic Target'
+    list_filter = ('period',)
 
 
 admin.site.register(IndicatorType)

--- a/indicators/models.py
+++ b/indicators/models.py
@@ -475,12 +475,6 @@ class PeriodicTarget(models.Model):
         return "%s %s" % (self.period, self.target)
 
 
-class PeriodicTargetAdmin(admin.ModelAdmin):
-    list_display = ('period', 'target', 'customsort',)
-    display = 'Indicator Periodic Target'
-    list_filter = ('period',)
-
-
 class CollectedDataManager(models.Manager):
     def get_queryset(self):
         return super(CollectedDataManager, self).get_queryset().prefetch_related('site','disaggregation_value').select_related('workflowlevel1','indicator','workflowlevel2','evidence','tola_table')


### PR DESCRIPTION
## Purpose
We need a export option for PeriodicTarget model on admin panel. 

## Approach
ImportExportModelAdmin added as a base class to PeriodicTargetAdmin model.

_Related ticket: humanitec/ActivityAPI#404
