### PR TITLE
Fix wrong field name in Widget factory

### DIFF
--- a/factories/workflow_models.py
+++ b/factories/workflow_models.py
@@ -128,7 +128,7 @@ class Widget(DjangoModelFactory):
         django_get_or_create = ('dashboard',)
 
     dashboard = SubFactory(Dashboard)
-    name = "My Crazy Widget"
+    title = "My Crazy Widget"
 
 
 class WorkflowLevel1(DjangoModelFactory):


### PR DESCRIPTION
## Purpose
It's not possible to generate widgets via factory because the field name is wrong. We need to fix it to be able to create it.