### PR TITLE
Set up email categories

### DIFF
--- a/tola/__init__.py
+++ b/tola/__init__.py
@@ -1,1 +1,3 @@
+STAGING_BRANCH = 'staging'
 DEMO_BRANCH = 'demo'
+PRODUCTION_BRANCH = 'master'


### PR DESCRIPTION
## Purpose
TolaData team needs to have the emails separated by the categories, so they can classify emails.

### Furter Info
Related ticket: https://github.com/Humanitec/ActivityAPI/issues/490
