### PR TITLE
add check for oauth domains are already used

### DIFF
--- a/workflow/models.py
+++ b/workflow/models.py
@@ -160,7 +160,17 @@ class Organization(models.Model):
         verbose_name_plural = "Organizations"
         app_label = 'workflow'
 
+    def clean_fields(self, exclude=None):
+        super(Organization, self).clean_fields(exclude=exclude)
+        if self.oauth_domains:
+            if Organization.objects.filter(
+                    oauth_domains__overlap=self.oauth_domains
+            ).exclude(organization_uuid=self.organization_uuid).exists():
+                raise ValidationError(
+                    'Oauth Domain already used by another organization')
+
     def save(self, *args, **kwargs):
+        self.full_clean()
         if self.create_date == None:
             self.create_date = timezone.now()
         self.edit_date = timezone.now()

--- a/workflow/tests/test_models.py
+++ b/workflow/tests/test_models.py
@@ -181,3 +181,10 @@ class OrganizationTest(TestCase):
         organization = factories.Organization(phone="+49 123 456 111")
         self.assertEqual(organization.phone, "+49 123 456 111")
 
+    def test_same_oauth_domain_fails_for_two_organization(self):
+        domain = 'example.com'
+        domain2 = 'test.com'
+        factories.Organization(oauth_domains=[domain, domain2])
+        org2 = factories.Organization()
+        org2.oauth_domains = [domain]
+        self.assertRaises(ValidationError, org2.save)


### PR DESCRIPTION
## Purpose
If same domain used for two or more organization, this situation causes login problem for users. When user try to add new organization or update existing one with new oauth domain, We need to check are that oauth domain already used for another organization.

## Approach
Clean_fields method added to check  oauth domains with other organizations. Therefore, if users try to add oauth domain which is already used in system, they will get validation error.

_Related ticket: humanitec/ActivityAPI#359
