### PR TITLE
Change django-requirement to latest 1.11

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-Django==1.11.3
+Django==1.11.17
 djangorestframework==3.6.3
 psycopg2>=2.7,<=2.8
 git+https://github.com/toladata/social-core#egg=social-core


### PR DESCRIPTION
- 1.11.17 of Dec 3, 2018

- For fixing open redirect vulnerability
CVE-2018-14574
moderate severity
Vulnerable versions: >= 1.11.0, < 1.11.15
Patched version: 1.11.15
django.middleware.common.CommonMiddleware in Django 1.11.x before 1.11.15 and 2.0.x before 2.0.8 has an Open Redirect.

- End of extended support until at least April 2020