### PR TITLE
Fix urllib3 vulnerability

### DIFF
--- a/requirements/pkg.txt
+++ b/requirements/pkg.txt
@@ -4,6 +4,6 @@ django-oauth-toolkit==1.1.2
 django-simple-history==1.9.0
 elasticsearch==5.4.0
 factory_boy==2.9.2
-urllib3==1.21.1
+urllib3>1.22<1.3
 voluptuous==0.11.1
 chargebee>=2,<3


### PR DESCRIPTION
CVE-2018-20060 More information
high severity
Vulnerable versions: < 1.23
Patched version: 1.23
urllib3 before version 1.23 does not remove the Authorization HTTP header when following a cross-origin redirect (i.e., a redirect that differs in host, port, or scheme). This can allow for credentials in the Authorization header to be exposed to unintended hosts or transmitted in cleartext.