### PR TITLE
TOLA-396: Remove check seat calls and its tests

### DIFF
--- a/workflow/tests/test_models.py
+++ b/workflow/tests/test_models.py
@@ -104,12 +104,12 @@ class WorkflowTeamTest(TestCase):
                          (u'Thom Yorke - ProgramAdmin <Health and Survival '
                           u'for Syrians in Affected Regions>'))
 
-    def test_save_role_org_admin_fails(self):
-        wfteam = factories.WorkflowTeam.build(
-            role=factories.Group(name=ROLE_ORGANIZATION_ADMIN),
-            workflow_user=factories.TolaUser(),
-            workflowlevel1=factories.WorkflowLevel1())
-        self.assertRaises(ValidationError, wfteam.save)
+    # def test_save_role_org_admin_fails(self):
+    #     wfteam = factories.WorkflowTeam.build(
+    #         role=factories.Group(name=ROLE_ORGANIZATION_ADMIN),
+    #         workflow_user=factories.TolaUser(),
+    #         workflowlevel1=factories.WorkflowLevel1())
+    #     self.assertRaises(ValidationError, wfteam.save)
 
 
 @tag('pkg')

--- a/workflow/tests/test_signals.py
+++ b/workflow/tests/test_signals.py
@@ -205,127 +205,127 @@ class CheckSeatsSaveWFTeamsTest(TestCase):
         self.org = factories.Organization(chargebee_subscription_id='12345')
         self.tola_user = factories.TolaUser(organization=self.org)
 
-    def test_check_seats_save_team_increase(self):
-        external_response = self.ExternalResponse(None)
-        Subscription.retrieve = Mock(return_value=external_response)
-        wflvl1_1 = factories.WorkflowLevel1(name='WorkflowLevel1_1')
-        wflvl1_2 = factories.WorkflowLevel1(name='WorkflowLevel1_2')
-        factories.WorkflowTeam(workflow_user=self.tola_user,
-                               workflowlevel1=wflvl1_1,
-                               role=self.group_program_admin)
+    # def test_check_seats_save_team_increase(self):
+    #     external_response = self.ExternalResponse(None)
+    #     Subscription.retrieve = Mock(return_value=external_response)
+    #     wflvl1_1 = factories.WorkflowLevel1(name='WorkflowLevel1_1')
+    #     wflvl1_2 = factories.WorkflowLevel1(name='WorkflowLevel1_2')
+    #     factories.WorkflowTeam(workflow_user=self.tola_user,
+    #                            workflowlevel1=wflvl1_1,
+    #                            role=self.group_program_admin)
+    #
+    #     # It should increase the seats because the user doesn't
+    #     # have any seat reserved for him
+    #     organization = Organization.objects.get(pk=self.org.id)
+    #     self.assertEqual(organization.chargebee_used_seats, 1)
+    #
+    #     # It shouldn't increase the seats because the user already
+    #     # has a seat reserved for him
+    #     factories.WorkflowTeam(workflow_user=self.tola_user,
+    #                            workflowlevel1=wflvl1_2,
+    #                            role=self.group_program_admin)
+    #     organization = Organization.objects.get(pk=self.org.id)
+    #     self.assertEqual(organization.chargebee_used_seats, 1)
 
-        # It should increase the seats because the user doesn't
-        # have any seat reserved for him
-        organization = Organization.objects.get(pk=self.org.id)
-        self.assertEqual(organization.chargebee_used_seats, 1)
+    # def test_check_seats_save_team_decrease(self):
+    #     external_response = self.ExternalResponse(None)
+    #     Subscription.retrieve = Mock(return_value=external_response)
+    #     wflvl1_1 = factories.WorkflowLevel1(name='WorkflowLevel1_1')
+    #     wflvl1_2 = factories.WorkflowLevel1(name='WorkflowLevel1_2')
+    #     wfteam1_1 = factories.WorkflowTeam(workflow_user=self.tola_user,
+    #                                        workflowlevel1=wflvl1_1,
+    #                                        role=self.group_program_admin)
+    #     wfteam1_2 = factories.WorkflowTeam(workflow_user=self.tola_user,
+    #                                        workflowlevel1=wflvl1_2,
+    #                                        role=self.group_program_admin)
+    #
+    #     # It shouldn't increase the amount of used seats
+    #     # the user already has a WorkflowTeam
+    #     organization = Organization.objects.get(pk=self.org.id)
+    #     self.assertEqual(organization.chargebee_used_seats, 1)
+    #
+    #     # It shouldn't decrease the seats because the user still has
+    #     # another WorkflowTeam
+    #     wfteam1_1.role = self.group_view_only
+    #     wfteam1_1.save()
+    #     organization = Organization.objects.get(pk=self.org.id)
+    #     self.assertEqual(organization.chargebee_used_seats, 1)
+    #
+    #     # It should decrease the seats because the user isn't Org Admin
+    #     # and doesn't have another WorkflowTeam
+    #     wfteam1_2.role = self.group_view_only
+    #     wfteam1_2.save()
+    #     organization = Organization.objects.get(pk=self.org.id)
+    #     self.assertEqual(organization.chargebee_used_seats, 0)
 
-        # It shouldn't increase the seats because the user already
-        # has a seat reserved for him
-        factories.WorkflowTeam(workflow_user=self.tola_user,
-                               workflowlevel1=wflvl1_2,
-                               role=self.group_program_admin)
-        organization = Organization.objects.get(pk=self.org.id)
-        self.assertEqual(organization.chargebee_used_seats, 1)
+    # def test_check_seats_save_team_without_subscription(self):
+    #     external_response = self.ExternalResponse(None)
+    #     Subscription.retrieve = Mock(return_value=external_response)
+    #     self.tola_user.organization = factories.Organization()
+    #     wflvl1 = factories.WorkflowLevel1(name='WorkflowLevel1')
+    #     factories.WorkflowTeam(workflow_user=self.tola_user,
+    #                            workflowlevel1=wflvl1,
+    #                            role=self.group_program_admin)
+    #
+    #     organization = Organization.objects.get(pk=self.org.id)
+    #     self.assertEqual(organization.chargebee_used_seats, 0)
 
-    def test_check_seats_save_team_decrease(self):
-        external_response = self.ExternalResponse(None)
-        Subscription.retrieve = Mock(return_value=external_response)
-        wflvl1_1 = factories.WorkflowLevel1(name='WorkflowLevel1_1')
-        wflvl1_2 = factories.WorkflowLevel1(name='WorkflowLevel1_2')
-        wfteam1_1 = factories.WorkflowTeam(workflow_user=self.tola_user,
-                                           workflowlevel1=wflvl1_1,
-                                           role=self.group_program_admin)
-        wfteam1_2 = factories.WorkflowTeam(workflow_user=self.tola_user,
-                                           workflowlevel1=wflvl1_2,
-                                           role=self.group_program_admin)
+    # @patch('workflow.signals.tsync')
+    # def test_check_seats_save_team_demo(self, mock_tsync):
+    #     os.environ['APP_BRANCH'] = DEMO_BRANCH
+    #     mock_tsync.create_instance.return_value = Mock()
+    #     self.tola_user.organization = factories.Organization()
+    #     wflvl1 = factories.WorkflowLevel1(name='WorkflowLevel1')
+    #     factories.WorkflowTeam(workflow_user=self.tola_user,
+    #                            workflowlevel1=wflvl1,
+    #                            role=self.group_program_admin)
+    #
+    #     organization = Organization.objects.get(pk=self.org.id)
+    #     self.assertEqual(organization.chargebee_used_seats, 0)
 
-        # It shouldn't increase the amount of used seats
-        # the user already has a WorkflowTeam
-        organization = Organization.objects.get(pk=self.org.id)
-        self.assertEqual(organization.chargebee_used_seats, 1)
+    # def test_check_seats_save_team_org_admin(self):
+    #     # When a user is an org admin, the seat has to be updated with the
+    #     # user groups signal, that's why it shouldn't be changed in this case.
+    #     self.tola_user.user.groups.add(self.group_org_admin)
+    #     self.tola_user.user.save()
+    #
+    #     external_response = self.ExternalResponse(None)
+    #     Subscription.retrieve = Mock(return_value=external_response)
+    #     wflvl1 = factories.WorkflowLevel1(name='WorkflowLevel1')
+    #     factories.WorkflowTeam(workflow_user=self.tola_user,
+    #                            workflowlevel1=wflvl1,
+    #                            role=self.group_program_admin)
+    #
+    #     # It should have only one seat because of the Org Admin role
+    #     organization = Organization.objects.get(pk=self.org.id)
+    #     self.assertEqual(organization.chargebee_used_seats, 1)
 
-        # It shouldn't decrease the seats because the user still has
-        # another WorkflowTeam
-        wfteam1_1.role = self.group_view_only
-        wfteam1_1.save()
-        organization = Organization.objects.get(pk=self.org.id)
-        self.assertEqual(organization.chargebee_used_seats, 1)
-
-        # It should decrease the seats because the user isn't Org Admin
-        # and doesn't have another WorkflowTeam
-        wfteam1_2.role = self.group_view_only
-        wfteam1_2.save()
-        organization = Organization.objects.get(pk=self.org.id)
-        self.assertEqual(organization.chargebee_used_seats, 0)
-
-    def test_check_seats_save_team_without_subscription(self):
-        external_response = self.ExternalResponse(None)
-        Subscription.retrieve = Mock(return_value=external_response)
-        self.tola_user.organization = factories.Organization()
-        wflvl1 = factories.WorkflowLevel1(name='WorkflowLevel1')
-        factories.WorkflowTeam(workflow_user=self.tola_user,
-                               workflowlevel1=wflvl1,
-                               role=self.group_program_admin)
-
-        organization = Organization.objects.get(pk=self.org.id)
-        self.assertEqual(organization.chargebee_used_seats, 0)
-
-    @patch('workflow.signals.tsync')
-    def test_check_seats_save_team_demo(self, mock_tsync):
-        os.environ['APP_BRANCH'] = DEMO_BRANCH
-        mock_tsync.create_instance.return_value = Mock()
-        self.tola_user.organization = factories.Organization()
-        wflvl1 = factories.WorkflowLevel1(name='WorkflowLevel1')
-        factories.WorkflowTeam(workflow_user=self.tola_user,
-                               workflowlevel1=wflvl1,
-                               role=self.group_program_admin)
-
-        organization = Organization.objects.get(pk=self.org.id)
-        self.assertEqual(organization.chargebee_used_seats, 0)
-
-    def test_check_seats_save_team_org_admin(self):
-        # When a user is an org admin, the seat has to be updated with the
-        # user groups signal, that's why it shouldn't be changed in this case.
-        self.tola_user.user.groups.add(self.group_org_admin)
-        self.tola_user.user.save()
-
-        external_response = self.ExternalResponse(None)
-        Subscription.retrieve = Mock(return_value=external_response)
-        wflvl1 = factories.WorkflowLevel1(name='WorkflowLevel1')
-        factories.WorkflowTeam(workflow_user=self.tola_user,
-                               workflowlevel1=wflvl1,
-                               role=self.group_program_admin)
-
-        # It should have only one seat because of the Org Admin role
-        organization = Organization.objects.get(pk=self.org.id)
-        self.assertEqual(organization.chargebee_used_seats, 1)
-
-    def test_check_seats_save_team_retrieve_subscription_fails(self):
-        """
-        The number of seats will be increased in the system but it's not
-        possible to check the quantity of the plan because the retrieve
-        failed.
-        """
-        self.tola_user.user.groups.add(self.group_org_admin)
-        self.tola_user.user.save()
-        self.org = Organization.objects.get(pk=self.org.id)
-        user = factories.User(first_name='John', last_name='Lennon')
-        tolauser = factories.TolaUser(user=user, organization=self.org)
-
-        json_obj = {
-            'message': "Sorry, we couldn't find that resource",
-            'error_code': 'resource_not_found'
-        }
-        sub_response = APIError(404, json_obj)
-        Subscription.retrieve = Mock(side_effect=sub_response)
-        wflvl1 = factories.WorkflowLevel1(name='WorkflowLevel1')
-        factories.WorkflowTeam(workflow_user=tolauser,
-                               workflowlevel1=wflvl1,
-                               role=self.group_program_admin)
-
-        organization = Organization.objects.get(pk=self.org.id)
-        self.assertEqual(organization.chargebee_used_seats, 2)
-        self.assertEqual(len(mail.outbox), 0)
+    # def test_check_seats_save_team_retrieve_subscription_fails(self):
+    #     """
+    #     The number of seats will be increased in the system but it's not
+    #     possible to check the quantity of the plan because the retrieve
+    #     failed.
+    #     """
+    #     self.tola_user.user.groups.add(self.group_org_admin)
+    #     self.tola_user.user.save()
+    #     self.org = Organization.objects.get(pk=self.org.id)
+    #     user = factories.User(first_name='John', last_name='Lennon')
+    #     tolauser = factories.TolaUser(user=user, organization=self.org)
+    #
+    #     json_obj = {
+    #         'message': "Sorry, we couldn't find that resource",
+    #         'error_code': 'resource_not_found'
+    #     }
+    #     sub_response = APIError(404, json_obj)
+    #     Subscription.retrieve = Mock(side_effect=sub_response)
+    #     wflvl1 = factories.WorkflowLevel1(name='WorkflowLevel1')
+    #     factories.WorkflowTeam(workflow_user=tolauser,
+    #                            workflowlevel1=wflvl1,
+    #                            role=self.group_program_admin)
+    #
+    #     organization = Organization.objects.get(pk=self.org.id)
+    #     self.assertEqual(organization.chargebee_used_seats, 2)
+    #     self.assertEqual(len(mail.outbox), 0)
 
 @tag('pkg')
 class CheckSeatsDeleteWFTeamsTest(TestCase):
@@ -343,70 +343,70 @@ class CheckSeatsDeleteWFTeamsTest(TestCase):
         self.org = factories.Organization(chargebee_subscription_id='12345')
         self.tola_user = factories.TolaUser(organization=self.org)
 
-    def test_check_seats_delete_team_decrease(self):
-        external_response = self.ExternalResponse(None)
-        Subscription.retrieve = Mock(return_value=external_response)
-        wflvl1 = factories.WorkflowLevel1(name='WorkflowLevel1')
-        wfteam = factories.WorkflowTeam(workflow_user=self.tola_user,
-                                        workflowlevel1=wflvl1,
-                                        role=self.group_program_admin)
+    # def test_check_seats_delete_team_decrease(self):
+    #     external_response = self.ExternalResponse(None)
+    #     Subscription.retrieve = Mock(return_value=external_response)
+    #     wflvl1 = factories.WorkflowLevel1(name='WorkflowLevel1')
+    #     wfteam = factories.WorkflowTeam(workflow_user=self.tola_user,
+    #                                     workflowlevel1=wflvl1,
+    #                                     role=self.group_program_admin)
+    #
+    #     organization = Organization.objects.get(pk=self.org.id)
+    #     self.assertEqual(organization.chargebee_used_seats, 1)
+    #
+    #     wfteam.delete()
+    #     organization = Organization.objects.get(pk=self.org.id)
+    #     self.assertEqual(organization.chargebee_used_seats, 0)
 
-        organization = Organization.objects.get(pk=self.org.id)
-        self.assertEqual(organization.chargebee_used_seats, 1)
+    # def test_check_seats_delete_team_not_decrease(self):
+    #     external_response = self.ExternalResponse(None)
+    #     Subscription.retrieve = Mock(return_value=external_response)
+    #     wflvl1_1 = factories.WorkflowLevel1(name='WorkflowLevel1_1')
+    #     wflvl1_2 = factories.WorkflowLevel1(name='WorkflowLevel1_2')
+    #     wfteam1_1 = factories.WorkflowTeam(workflow_user=self.tola_user,
+    #                                        workflowlevel1=wflvl1_1,
+    #                                        role=self.group_program_admin)
+    #     factories.WorkflowTeam(workflow_user=self.tola_user,
+    #                            workflowlevel1=wflvl1_2,
+    #                            role=self.group_program_admin)
+    #
+    #     organization = Organization.objects.get(pk=self.org.id)
+    #     self.assertEqual(organization.chargebee_used_seats, 1)
+    #
+    #     wfteam1_1.delete()
+    #     organization = Organization.objects.get(pk=self.org.id)
+    #     self.assertEqual(organization.chargebee_used_seats, 1)
 
-        wfteam.delete()
-        organization = Organization.objects.get(pk=self.org.id)
-        self.assertEqual(organization.chargebee_used_seats, 0)
+    # @patch('workflow.signals.tsync')
+    # def test_check_seats_save_team_demo(self, mock_tsync):
+    #     os.environ['APP_BRANCH'] = DEMO_BRANCH
+    #     mock_tsync.create_instance.return_value = Mock()
+    #     self.tola_user.organization = factories.Organization()
+    #     wflvl1 = factories.WorkflowLevel1(name='WorkflowLevel1')
+    #     factories.WorkflowTeam(workflow_user=self.tola_user,
+    #                            workflowlevel1=wflvl1,
+    #                            role=self.group_program_admin)
+    #
+    #     organization = Organization.objects.get(pk=self.org.id)
+    #     self.assertEqual(organization.chargebee_used_seats, 0)
 
-    def test_check_seats_delete_team_not_decrease(self):
-        external_response = self.ExternalResponse(None)
-        Subscription.retrieve = Mock(return_value=external_response)
-        wflvl1_1 = factories.WorkflowLevel1(name='WorkflowLevel1_1')
-        wflvl1_2 = factories.WorkflowLevel1(name='WorkflowLevel1_2')
-        wfteam1_1 = factories.WorkflowTeam(workflow_user=self.tola_user,
-                                           workflowlevel1=wflvl1_1,
-                                           role=self.group_program_admin)
-        factories.WorkflowTeam(workflow_user=self.tola_user,
-                               workflowlevel1=wflvl1_2,
-                               role=self.group_program_admin)
-
-        organization = Organization.objects.get(pk=self.org.id)
-        self.assertEqual(organization.chargebee_used_seats, 1)
-
-        wfteam1_1.delete()
-        organization = Organization.objects.get(pk=self.org.id)
-        self.assertEqual(organization.chargebee_used_seats, 1)
-
-    @patch('workflow.signals.tsync')
-    def test_check_seats_save_team_demo(self, mock_tsync):
-        os.environ['APP_BRANCH'] = DEMO_BRANCH
-        mock_tsync.create_instance.return_value = Mock()
-        self.tola_user.organization = factories.Organization()
-        wflvl1 = factories.WorkflowLevel1(name='WorkflowLevel1')
-        factories.WorkflowTeam(workflow_user=self.tola_user,
-                               workflowlevel1=wflvl1,
-                               role=self.group_program_admin)
-
-        organization = Organization.objects.get(pk=self.org.id)
-        self.assertEqual(organization.chargebee_used_seats, 0)
-
-    def test_check_seats_save_team_org_admin(self):
-        external_response = self.ExternalResponse(None)
-        Subscription.retrieve = Mock(return_value=external_response)
-        self.tola_user.user.groups.add(self.group_org_admin)
-        self.tola_user.user.save()
-
-        wflvl1 = factories.WorkflowLevel1(name='WorkflowLevel1')
-        wfteam = factories.WorkflowTeam(workflow_user=self.tola_user,
-                                        workflowlevel1=wflvl1,
-                                        role=self.group_program_admin)
-
-        organization = Organization.objects.get(pk=self.org.id)
-        self.assertEqual(organization.chargebee_used_seats, 1)
-
-        wfteam.delete()
-        organization = Organization.objects.get(pk=self.org.id)
-        self.assertEqual(organization.chargebee_used_seats, 1)
+    # def test_check_seats_save_team_org_admin(self):
+    #     external_response = self.ExternalResponse(None)
+    #     Subscription.retrieve = Mock(return_value=external_response)
+    #     self.tola_user.user.groups.add(self.group_org_admin)
+    #     self.tola_user.user.save()
+    #
+    #     wflvl1 = factories.WorkflowLevel1(name='WorkflowLevel1')
+    #     wfteam = factories.WorkflowTeam(workflow_user=self.tola_user,
+    #                                     workflowlevel1=wflvl1,
+    #                                     role=self.group_program_admin)
+    #
+    #     organization = Organization.objects.get(pk=self.org.id)
+    #     self.assertEqual(organization.chargebee_used_seats, 1)
+    #
+    #     wfteam.delete()
+    #     organization = Organization.objects.get(pk=self.org.id)
+    #     self.assertEqual(organization.chargebee_used_seats, 1)
 
 
 @tag('pkg')
@@ -426,103 +426,103 @@ class CheckSeatsSaveUserGroupTest(TestCase):
         self.org = factories.Organization(chargebee_subscription_id='12345')
         self.tola_user = factories.TolaUser(organization=self.org)
 
-    def test_check_seats_save_user_groups_increase(self):
-        external_response = self.ExternalResponse(None)
-        Subscription.retrieve = Mock(return_value=external_response)
+    # def test_check_seats_save_user_groups_increase(self):
+    #     external_response = self.ExternalResponse(None)
+    #     Subscription.retrieve = Mock(return_value=external_response)
+    #
+    #     self.tola_user.user.groups.add(self.group_org_admin)
+    #     self.tola_user.user.save()
+    #
+    #     # It should have only one seat because of the Org Admin role
+    #     organization = Organization.objects.get(pk=self.org.id)
+    #     self.assertEqual(organization.chargebee_used_seats, 1)
 
-        self.tola_user.user.groups.add(self.group_org_admin)
-        self.tola_user.user.save()
+    # def test_check_seats_save_user_groups_decrease(self):
+    #     external_response = self.ExternalResponse(None)
+    #     Subscription.retrieve = Mock(return_value=external_response)
+    #
+    #     self.tola_user.user.groups.add(self.group_org_admin)
+    #     self.tola_user.user.save()
+    #
+    #     # It should have only one seat because of the Org Admin role
+    #     organization = Organization.objects.get(pk=self.org.id)
+    #     self.assertEqual(organization.chargebee_used_seats, 1)
+    #
+    #     self.tola_user.user.groups.remove(self.group_org_admin)
+    #
+    #     # The user doesn't have any WorkflowTeam and isn't Org Admin anymore
+    #     organization = Organization.objects.get(pk=self.org.id)
+    #     self.assertEqual(organization.chargebee_used_seats, 0)
 
-        # It should have only one seat because of the Org Admin role
-        organization = Organization.objects.get(pk=self.org.id)
-        self.assertEqual(organization.chargebee_used_seats, 1)
+    # def test_check_seats_save_user_groups_viewonly_doent_affect(self):
+    #     external_response = self.ExternalResponse(None)
+    #     Subscription.retrieve = Mock(return_value=external_response)
+    #
+    #     self.tola_user.user.groups.add(self.group_view_only)
+    #     self.tola_user.user.save()
+    #
+    #     # It should have only one seat because of the Org Admin role
+    #     organization = Organization.objects.get(pk=self.org.id)
+    #     self.assertEqual(organization.chargebee_used_seats, 0)
+    #
+    #     self.tola_user.user.groups.remove(self.group_view_only)
+    #
+    #     # The user doesn't have any WorkflowTeam and isn't Org Admin anymore
+    #     organization = Organization.objects.get(pk=self.org.id)
+    #     self.assertEqual(organization.chargebee_used_seats, 0)
 
-    def test_check_seats_save_user_groups_decrease(self):
-        external_response = self.ExternalResponse(None)
-        Subscription.retrieve = Mock(return_value=external_response)
+    # def test_check_seats_save_user_groups_without_subscription(self):
+    #     external_response = self.ExternalResponse(None)
+    #     Subscription.retrieve = Mock(return_value=external_response)
+    #
+    #     self.tola_user.organization = factories.Organization()
+    #     self.tola_user.save()
+    #
+    #     self.tola_user.user.groups.add(self.group_org_admin)
+    #     self.tola_user.user.save()
+    #
+    #     # It should have only one seat because of the Org Admin role
+    #     organization = Organization.objects.get(pk=self.org.id)
+    #     self.assertEqual(organization.chargebee_used_seats, 0)
 
-        self.tola_user.user.groups.add(self.group_org_admin)
-        self.tola_user.user.save()
+    # @patch('workflow.signals.tsync')
+    # def test_check_seats_save_user_groups_demo(self, mock_tsync):
+    #     os.environ['APP_BRANCH'] = DEMO_BRANCH
+    #     mock_tsync.create_instance.return_value = Mock()
+    #     self.tola_user.organization = factories.Organization()
+    #     self.tola_user.save()
+    #
+    #     self.tola_user.user.groups.add(self.group_org_admin)
+    #     self.tola_user.user.save()
+    #
+    #     # It should have only one seat because of the Org Admin role
+    #     organization = Organization.objects.get(pk=self.org.id)
+    #     self.assertEqual(organization.chargebee_used_seats, 0)
 
-        # It should have only one seat because of the Org Admin role
-        organization = Organization.objects.get(pk=self.org.id)
-        self.assertEqual(organization.chargebee_used_seats, 1)
-
-        self.tola_user.user.groups.remove(self.group_org_admin)
-
-        # The user doesn't have any WorkflowTeam and isn't Org Admin anymore
-        organization = Organization.objects.get(pk=self.org.id)
-        self.assertEqual(organization.chargebee_used_seats, 0)
-
-    def test_check_seats_save_user_groups_viewonly_doent_affect(self):
-        external_response = self.ExternalResponse(None)
-        Subscription.retrieve = Mock(return_value=external_response)
-
-        self.tola_user.user.groups.add(self.group_view_only)
-        self.tola_user.user.save()
-
-        # It should have only one seat because of the Org Admin role
-        organization = Organization.objects.get(pk=self.org.id)
-        self.assertEqual(organization.chargebee_used_seats, 0)
-
-        self.tola_user.user.groups.remove(self.group_view_only)
-
-        # The user doesn't have any WorkflowTeam and isn't Org Admin anymore
-        organization = Organization.objects.get(pk=self.org.id)
-        self.assertEqual(organization.chargebee_used_seats, 0)
-
-    def test_check_seats_save_user_groups_without_subscription(self):
-        external_response = self.ExternalResponse(None)
-        Subscription.retrieve = Mock(return_value=external_response)
-
-        self.tola_user.organization = factories.Organization()
-        self.tola_user.save()
-
-        self.tola_user.user.groups.add(self.group_org_admin)
-        self.tola_user.user.save()
-
-        # It should have only one seat because of the Org Admin role
-        organization = Organization.objects.get(pk=self.org.id)
-        self.assertEqual(organization.chargebee_used_seats, 0)
-
-    @patch('workflow.signals.tsync')
-    def test_check_seats_save_user_groups_demo(self, mock_tsync):
-        os.environ['APP_BRANCH'] = DEMO_BRANCH
-        mock_tsync.create_instance.return_value = Mock()
-        self.tola_user.organization = factories.Organization()
-        self.tola_user.save()
-
-        self.tola_user.user.groups.add(self.group_org_admin)
-        self.tola_user.user.save()
-
-        # It should have only one seat because of the Org Admin role
-        organization = Organization.objects.get(pk=self.org.id)
-        self.assertEqual(organization.chargebee_used_seats, 0)
-
-    def test_check_seats_save_user_groups_retrieve_subscription_fails(self):
-        """
-        The number of seats will be increased in the system but it's not
-        possible to check the quantity of the plan because the retrieve
-        failed.
-        """
-        json_obj = {
-            'message': "Sorry, we couldn't find that resource",
-            'error_code': 'resource_not_found'
-        }
-        sub_response = APIError(404, json_obj)
-        Subscription.retrieve = Mock(side_effect=sub_response)
-        self.tola_user.user.groups.add(self.group_org_admin)
-        self.tola_user.user.save()
-
-        self.org = Organization.objects.get(pk=self.org.id)
-        user = factories.User(first_name='John', last_name='Lennon')
-        tolauser = factories.TolaUser(user=user, organization=self.org)
-        tolauser.user.groups.add(self.group_org_admin)
-        tolauser.user.save()
-
-        organization = Organization.objects.get(pk=self.org.id)
-        self.assertEqual(organization.chargebee_used_seats, 2)
-        self.assertEqual(len(mail.outbox), 0)
+    # def test_check_seats_save_user_groups_retrieve_subscription_fails(self):
+    #     """
+    #     The number of seats will be increased in the system but it's not
+    #     possible to check the quantity of the plan because the retrieve
+    #     failed.
+    #     """
+    #     json_obj = {
+    #         'message': "Sorry, we couldn't find that resource",
+    #         'error_code': 'resource_not_found'
+    #     }
+    #     sub_response = APIError(404, json_obj)
+    #     Subscription.retrieve = Mock(side_effect=sub_response)
+    #     self.tola_user.user.groups.add(self.group_org_admin)
+    #     self.tola_user.user.save()
+    #
+    #     self.org = Organization.objects.get(pk=self.org.id)
+    #     user = factories.User(first_name='John', last_name='Lennon')
+    #     tolauser = factories.TolaUser(user=user, organization=self.org)
+    #     tolauser.user.groups.add(self.group_org_admin)
+    #     tolauser.user.save()
+    #
+    #     organization = Organization.objects.get(pk=self.org.id)
+    #     self.assertEqual(organization.chargebee_used_seats, 2)
+    #     self.assertEqual(len(mail.outbox), 0)
 
 @tag('pkg')
 class AddPublicUrlTokenTest(TestCase):


### PR DESCRIPTION
## Purpose
Changing user organizations or adding users sometimes failed due to the chargebee seats check.

## Approach
I commented out parts of code where that chargebee seat check was happening. I also commented out their respective tests.
